### PR TITLE
feat: add 14 destination collections with complete Strapi setup

### DIFF
--- a/src/api/abu-dhabi/content-types/abu-dhabi/schema.json
+++ b/src/api/abu-dhabi/content-types/abu-dhabi/schema.json
@@ -1,0 +1,209 @@
+{
+  "kind": "collectionType",
+  "collectionName": "abu_dhabis",
+  "info": {
+    "singularName": "abu-dhabi",
+    "pluralName": "abu-dhabis",
+    "displayName": "Abu Dhabi",
+    "description": "Información detallada sobre Abu Dhabi como destino de estudio y trabajo"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "title": {
+      "type": "string",
+      "required": true,
+      "maxLength": 255,
+      "default": "Abu Dhabi"
+    },
+    "slug": {
+      "type": "uid",
+      "targetField": "title",
+      "required": true
+    },
+    "description": {
+      "type": "richtext",
+      "required": true
+    },
+    "shortDescription": {
+      "type": "text",
+      "maxLength": 500
+    },
+    "image": {
+      "type": "media",
+      "multiple": false,
+      "required": true,
+      "allowedTypes": ["images"]
+    },
+    "gallery": {
+      "type": "media",
+      "multiple": true,
+      "allowedTypes": ["images"]
+    },
+    "whyChooseTitle": {
+      "type": "string",
+      "default": "¿Por qué elegir Abu Dhabi?"
+    },
+    "whyChooseItems": {
+      "type": "json"
+    },
+    "hospitalityTitle": {
+      "type": "string",
+      "default": "Capital Cultural"
+    },
+    "hospitalityDescription": {
+      "type": "string",
+      "default": "Centro cultural y político de los Emiratos Árabes Unidos"
+    },
+    "hospitalityIcon": {
+      "type": "string",
+      "default": "🏛️"
+    },
+    "educationTitle": {
+      "type": "string",
+      "default": "Educación de Excelencia"
+    },
+    "educationDescription": {
+      "type": "string",
+      "default": "Universidades internacionales y centros de investigación"
+    },
+    "educationIcon": {
+      "type": "string",
+      "default": "🎓"
+    },
+    "cultureTitle": {
+      "type": "string",
+      "default": "Tradición Árabe"
+    },
+    "cultureDescription": {
+      "type": "string",
+      "default": "Inmersión en la rica cultura árabe e islámica"
+    },
+    "cultureIcon": {
+      "type": "string",
+      "default": "🕌"
+    },
+    "languageTitle": {
+      "type": "string",
+      "default": "Idiomas Múltiples"
+    },
+    "languageDescription": {
+      "type": "string",
+      "default": "Aprende árabe e inglés en un entorno multicultural"
+    },
+    "languageIcon": {
+      "type": "string",
+      "default": "🗣️"
+    },
+    "qualityTitle": {
+      "type": "string",
+      "default": "Calidad de Vida"
+    },
+    "qualityDescription": {
+      "type": "string",
+      "default": "Infraestructura moderna y servicios de primera clase"
+    },
+    "qualityIcon": {
+      "type": "string",
+      "default": "🏙️"
+    },
+    "opportunitiesTitle": {
+      "type": "string",
+      "default": "Oportunidades Profesionales"
+    },
+    "opportunitiesDescription": {
+      "type": "string",
+      "default": "Carrera en empresas multinacionales y sector público"
+    },
+    "opportunitiesIcon": {
+      "type": "string",
+      "default": "💼"
+    },
+    "statisticsTitle": {
+      "type": "string",
+      "default": "Abu Dhabi en números"
+    },
+    "statistics": {
+      "type": "json"
+    },
+    "featuresTitle": {
+      "type": "string",
+      "default": "Características de Abu Dhabi"
+    },
+    "features": {
+      "type": "json"
+    },
+    "travelTipsTitle": {
+      "type": "string",
+      "default": "Tips de viaje para Abu Dhabi"
+    },
+    "travelTips": {
+      "type": "json"
+    },
+    "programs": {
+      "type": "json"
+    },
+    "requirements": {
+      "type": "json"
+    },
+    "overview": {
+      "type": "json"
+    },
+    "highlights": {
+      "type": "json"
+    },
+    "pricing": {
+      "type": "json"
+    },
+    "accommodation": {
+      "type": "json"
+    },
+    "transportation": {
+      "type": "json"
+    },
+    "climate": {
+      "type": "json"
+    },
+    "culture": {
+      "type": "json"
+    },
+    "education": {
+      "type": "json"
+    },
+    "workOpportunities": {
+      "type": "json"
+    },
+    "visaInfo": {
+      "type": "json"
+    },
+    "costOfLiving": {
+      "type": "json"
+    },
+    "safety": {
+      "type": "json"
+    },
+    "attractions": {
+      "type": "json"
+    },
+    "events": {
+      "type": "json"
+    },
+    "testimonials": {
+      "type": "json"
+    },
+    "faq": {
+      "type": "json"
+    },
+    "seoTitle": {
+      "type": "string"
+    },
+    "seoDescription": {
+      "type": "text"
+    },
+    "seoKeywords": {
+      "type": "json"
+    }
+  }
+}

--- a/src/api/abu-dhabi/controllers/abu-dhabi.js
+++ b/src/api/abu-dhabi/controllers/abu-dhabi.js
@@ -1,0 +1,94 @@
+'use strict';
+
+/**
+ * abu-dhabi controller
+ */
+
+const { createCoreController } = require('@strapi/strapi').factories;
+
+module.exports = createCoreController('api::abu-dhabi.abu-dhabi', ({ strapi }) => ({
+  // Método personalizado para obtener información completa de Abu Dhabi
+  async findComplete(ctx) {
+    const entities = await strapi.entityService.findMany('api::abu-dhabi.abu-dhabi', {
+      filters: { active: true },
+      populate: {
+        image: true,
+        gallery: true
+      }
+    });
+
+    return entities;
+  },
+
+  // Método personalizado para obtener estadísticas de Abu Dhabi
+  async findStats(ctx) {
+    const entities = await strapi.entityService.findMany('api::abu-dhabi.abu-dhabi', {
+      filters: { active: true },
+      populate: {
+        image: true
+      }
+    });
+
+    // Retornar solo las estadísticas
+    return entities.map(entity => ({
+      id: entity.id,
+      title: entity.title,
+      statistics: entity.statistics,
+      statisticsTitle: entity.statisticsTitle
+    }));
+  },
+
+  // Método personalizado para obtener tips de viaje
+  async findTravelTips(ctx) {
+    const entities = await strapi.entityService.findMany('api::abu-dhabi.abu-dhabi', {
+      filters: { active: true },
+      populate: {
+        image: true
+      }
+    });
+
+    // Retornar solo los tips de viaje
+    return entities.map(entity => ({
+      id: entity.id,
+      title: entity.title,
+      travelTips: entity.travelTips,
+      travelTipsTitle: entity.travelTipsTitle
+    }));
+  },
+
+  // Método personalizado para obtener características de Abu Dhabi
+  async findFeatures(ctx) {
+    const entities = await strapi.entityService.findMany('api::abu-dhabi.abu-dhabi', {
+      filters: { active: true },
+      populate: {
+        image: true
+      }
+    });
+
+    // Retornar solo las características
+    return entities.map(entity => ({
+      id: entity.id,
+      title: entity.title,
+      features: entity.features,
+      featuresTitle: entity.featuresTitle
+    }));
+  },
+
+  // Método personalizado para obtener información de programas
+  async findPrograms(ctx) {
+    const entities = await strapi.entityService.findMany('api::abu-dhabi.abu-dhabi', {
+      filters: { active: true },
+      populate: {
+        image: true
+      }
+    });
+
+    // Retornar solo la información de programas
+    return entities.map(entity => ({
+      id: entity.id,
+      title: entity.title,
+      programs: entity.programs,
+      requirements: entity.requirements
+    }));
+  }
+}));

--- a/src/api/abu-dhabi/routes/abu-dhabi.js
+++ b/src/api/abu-dhabi/routes/abu-dhabi.js
@@ -1,0 +1,37 @@
+'use strict';
+
+/**
+ * abu-dhabi router
+ */
+
+const { createCoreRouter } = require('@strapi/strapi').factories;
+
+module.exports = createCoreRouter('api::abu-dhabi.abu-dhabi', {
+  config: {
+    find: {
+      auth: false,
+      policies: [],
+      middlewares: [],
+    },
+    findOne: {
+      auth: false,
+      policies: [],
+      middlewares: [],
+    },
+    create: {
+      auth: {
+        strategy: 'jwt',
+      },
+    },
+    update: {
+      auth: {
+        strategy: 'jwt',
+      },
+    },
+    delete: {
+      auth: {
+        strategy: 'jwt',
+      },
+    },
+  },
+});

--- a/src/api/abu-dhabi/routes/custom-routes.js
+++ b/src/api/abu-dhabi/routes/custom-routes.js
@@ -1,0 +1,50 @@
+'use strict';
+
+/**
+ * Custom routes for abu-dhabi
+ */
+
+module.exports = {
+  routes: [
+    {
+      method: 'GET',
+      path: '/abu-dhabis/complete',
+      handler: 'abu-dhabi.findComplete',
+      config: {
+        auth: false,
+      },
+    },
+    {
+      method: 'GET',
+      path: '/abu-dhabis/stats',
+      handler: 'abu-dhabi.findStats',
+      config: {
+        auth: false,
+      },
+    },
+    {
+      method: 'GET',
+      path: '/abu-dhabis/travel-tips',
+      handler: 'abu-dhabi.findTravelTips',
+      config: {
+        auth: false,
+      },
+    },
+    {
+      method: 'GET',
+      path: '/abu-dhabis/features',
+      handler: 'abu-dhabi.findFeatures',
+      config: {
+        auth: false,
+      },
+    },
+    {
+      method: 'GET',
+      path: '/abu-dhabis/programs',
+      handler: 'abu-dhabi.findPrograms',
+      config: {
+        auth: false,
+      },
+    },
+  ],
+};

--- a/src/api/abu-dhabi/sample-data.json
+++ b/src/api/abu-dhabi/sample-data.json
@@ -1,0 +1,273 @@
+{
+  "abuDhabiData": [
+    {
+      "title": "Abu Dhabi",
+      "slug": "abu-dhabi",
+      "description": "Descubre Abu Dhabi, la capital cultural y política de los Emiratos Árabes Unidos. Oportunidades únicas en educación, cultura, tecnología y negocios en un entorno que combina tradición árabe con modernidad.",
+      "shortDescription": "Capital cultural con tradición árabe y modernidad",
+      "featured": true,
+      "active": true,
+      "whyChooseTitle": "¿Por qué elegir Abu Dhabi?",
+      "whyChooseItems": [
+        {
+          "title": "Capital Cultural",
+          "description": "Centro cultural y político de los Emiratos Árabes Unidos",
+          "icon": "🏛️"
+        },
+        {
+          "title": "Educación de Excelencia",
+          "description": "Universidades internacionales y centros de investigación",
+          "icon": "🎓"
+        },
+        {
+          "title": "Tradición Árabe",
+          "description": "Inmersión en la rica cultura árabe e islámica",
+          "icon": "🕌"
+        },
+        {
+          "title": "Idiomas Múltiples",
+          "description": "Aprende árabe e inglés en un entorno multicultural",
+          "icon": "🗣️"
+        },
+        {
+          "title": "Calidad de Vida",
+          "description": "Infraestructura moderna y servicios de primera clase",
+          "icon": "🏙️"
+        },
+        {
+          "title": "Oportunidades Profesionales",
+          "description": "Carrera en empresas multinacionales y sector público",
+          "icon": "💼"
+        }
+      ],
+      "statisticsTitle": "Abu Dhabi en números",
+      "statistics": [
+        {
+          "value": "1.5M+",
+          "label": "Habitantes"
+        },
+        {
+          "value": "80%",
+          "label": "Población extranjera"
+        },
+        {
+          "value": "0%",
+          "label": "Impuesto sobre la renta"
+        },
+        {
+          "value": "200+",
+          "label": "Islas"
+        }
+      ],
+      "featuresTitle": "Características de Abu Dhabi",
+      "features": [
+        {
+          "title": "Capital Cultural",
+          "description": "Centro cultural y político de los Emiratos Árabes Unidos",
+          "icon": "🏛️"
+        },
+        {
+          "title": "Educación Internacional",
+          "description": "Universidades de prestigio mundial",
+          "icon": "🎓"
+        },
+        {
+          "title": "Tradición Árabe",
+          "description": "Cultura árabe e islámica auténtica",
+          "icon": "🕌"
+        },
+        {
+          "title": "Tecnología Avanzada",
+          "description": "Hub tecnológico en el Medio Oriente",
+          "icon": "💻"
+        }
+      ],
+      "travelTipsTitle": "Tips de viaje para Abu Dhabi",
+      "travelTips": [
+        {
+          "title": "Visa de Trabajo",
+          "description": "Proceso de visa para profesionales calificados."
+        },
+        {
+          "title": "Cultura Local",
+          "description": "Respeto por las tradiciones islámicas y la cultura local."
+        },
+        {
+          "title": "Clima Desértico",
+          "description": "Preparación para clima cálido y seco."
+        },
+        {
+          "title": "Transporte",
+          "description": "Sistema de transporte público moderno y eficiente."
+        }
+      ],
+      "programs": [
+        "work-and-study",
+        "internship",
+        "study-abroad"
+      ],
+      "requirements": [
+        "Nivel de inglés avanzado",
+        "Título universitario",
+        "Experiencia profesional",
+        "Mayor de 21 años"
+      ],
+      "overview": {
+        "highlights": [
+          {
+            "title": "Capital Cultural",
+            "description": "Centro cultural y político de los Emiratos Árabes Unidos",
+            "icon": "Building"
+          },
+          {
+            "title": "Educación de Excelencia",
+            "description": "Universidades internacionales y centros de investigación",
+            "icon": "GraduationCap"
+          },
+          {
+            "title": "Tradición Árabe",
+            "description": "Inmersión en la rica cultura árabe e islámica",
+            "icon": "Mosque"
+          }
+        ],
+        "features": [
+          {
+            "title": "Idiomas Múltiples",
+            "description": "Aprende árabe e inglés en un entorno multicultural"
+          },
+          {
+            "title": "Calidad de Vida",
+            "description": "Infraestructura moderna y servicios de primera clase"
+          },
+          {
+            "title": "Oportunidades Profesionales",
+            "description": "Carrera en empresas multinacionales y sector público"
+          }
+        ]
+      },
+      "pricing": {
+        "accommodation": "600-1500 USD/mes",
+        "food": "300-600 USD/mes",
+        "transportation": "100-200 USD/mes",
+        "medicalInsurance": "100-200 USD/mes",
+        "visaFee": "200-400 USD",
+        "languageCourse": "300-600 USD/mes"
+      },
+      "accommodation": {
+        "sharedAccommodation": "600-1000 USD/mes",
+        "privateAccommodation": "1200-2500 USD/mes",
+        "servicedApartment": "1500-3000 USD/mes",
+        "studentHousing": "500-800 USD/mes"
+      },
+      "transportation": {
+        "publicTransport": "Sistema de autobuses y taxis",
+        "taxi": "Disponible y relativamente económico",
+        "metro": "En desarrollo",
+        "airport": "Conexión directa al aeropuerto"
+      },
+      "climate": {
+        "description": "Clima desértico con veranos muy calurosos e inviernos templados",
+        "temperature": "15-45°C promedio anual",
+        "rainfall": "Muy escasas lluvias",
+        "seasons": "Verano caluroso (mayo-septiembre) e invierno templado (octubre-abril)"
+      },
+      "culture": {
+        "language": "Árabe (oficial) e Inglés (ampliamente hablado)",
+        "religion": "Islam (predominante)",
+        "traditions": "Tradiciones islámicas, hospitalidad árabe, arte islámico",
+        "festivals": "Ramadán, Eid al-Fitr, Eid al-Adha, Festival de Abu Dhabi"
+      },
+      "education": {
+        "universities": "Universidades internacionales de prestigio",
+        "languageSchools": "Cursos de árabe e inglés disponibles",
+        "quality": "Educación de clase mundial",
+        "costs": "Educación de calidad con becas disponibles"
+      },
+      "workOpportunities": {
+        "fullTime": "Posiciones en educación, tecnología y negocios",
+        "sectors": "Educación, tecnología, petróleo, turismo, gobierno",
+        "minimumWage": "Salario competitivo sin impuestos",
+        "networking": "Excelentes oportunidades de networking regional"
+      },
+      "visaInfo": {
+        "type": "Visa de Trabajo",
+        "duration": "Hasta 2 años (renovable)",
+        "requirements": "Contrato de trabajo, certificados médicos, antecedentes penales",
+        "processingTime": "2-4 semanas"
+      },
+      "costOfLiving": {
+        "monthly": "1200-2500 USD",
+        "accommodation": "600-1500 USD/mes",
+        "food": "300-600 USD/mes",
+        "transport": "100-200 USD/mes",
+        "entertainment": "200-400 USD/mes"
+      },
+      "safety": {
+        "level": "Muy seguro",
+        "crimeRate": "Muy baja",
+        "emergency": "999 (policía), 998 (ambulancia)",
+        "tips": "Ciudad muy segura con leyes estrictas"
+      },
+      "attractions": [
+        "Mezquita Sheikh Zayed",
+        "Louvre Abu Dhabi",
+        "Palacio Qasr Al Hosn",
+        "Isla Saadiyat",
+        "Mercado Central",
+        "Corniche"
+      ],
+      "events": [
+        "Festival de Abu Dhabi",
+        "Ramadán",
+        "Eid al-Fitr",
+        "Eid al-Adha",
+        "Abu Dhabi Grand Prix",
+        "Festival de Cine"
+      ],
+      "testimonials": [
+        {
+          "name": "Ahmed Al-Rashid",
+          "content": "Abu Dhabi me ofreció una experiencia cultural única y oportunidades profesionales excepcionales.",
+          "program": "Work and Study",
+          "rating": 5
+        },
+        {
+          "name": "Sarah Johnson",
+          "content": "La educación en Abu Dhabi es de clase mundial. Las universidades son increíbles.",
+          "program": "Study Abroad",
+          "rating": 5
+        }
+      ],
+      "faq": [
+        {
+          "question": "¿Necesito visa para trabajar en Abu Dhabi?",
+          "answer": "Sí, necesitas una visa de trabajo que generalmente gestiona tu empleador. Te ayudamos con todo el proceso."
+        },
+        {
+          "question": "¿Puedo trabajar en Abu Dhabi sin experiencia previa?",
+          "answer": "Se requiere experiencia profesional y título universitario para la mayoría de posiciones."
+        },
+        {
+          "question": "¿Qué nivel de inglés necesito?",
+          "answer": "Recomendamos nivel avanzado, ya que el inglés es ampliamente usado en el sector profesional."
+        },
+        {
+          "question": "¿Es caro vivir en Abu Dhabi?",
+          "answer": "Abu Dhabi tiene un costo de vida moderado, pero los salarios son competitivos y no hay impuestos."
+        }
+      ],
+      "seoTitle": "Trabaja y Estudia en Abu Dhabi - Programas Internacionales",
+      "seoDescription": "Descubre las mejores oportunidades de trabajo y estudio en Abu Dhabi. Capital cultural con educación de excelencia.",
+      "seoKeywords": [
+        "Abu Dhabi",
+        "trabajar en Abu Dhabi",
+        "estudiar en Abu Dhabi",
+        "capital cultural",
+        "educación internacional",
+        "visa de trabajo",
+        "Emiratos Árabes",
+        "cultura árabe"
+      ]
+    }
+  ]
+}

--- a/src/api/abu-dhabi/services/abu-dhabi.js
+++ b/src/api/abu-dhabi/services/abu-dhabi.js
@@ -1,0 +1,74 @@
+'use strict';
+
+/**
+ * abu-dhabi service
+ */
+
+const { createCoreService } = require('@strapi/strapi').factories;
+
+module.exports = createCoreService('api::abu-dhabi.abu-dhabi', ({ strapi }) => ({
+  // Método personalizado para obtener información completa de Abu Dhabi
+  async findCompleteInfo() {
+    const abuDhabi = await strapi.entityService.findMany('api::abu-dhabi.abu-dhabi', {
+      filters: { active: true },
+      populate: {
+        image: true,
+        gallery: true
+      }
+    });
+
+    return abuDhabi;
+  },
+
+  // Método para obtener estadísticas específicas
+  async findStatistics() {
+    const abuDhabi = await strapi.entityService.findMany('api::abu-dhabi.abu-dhabi', {
+      filters: { active: true }
+    });
+
+    return abuDhabi.map(item => ({
+      id: item.id,
+      statistics: item.statistics,
+      statisticsTitle: item.statisticsTitle
+    }));
+  },
+
+  // Método para obtener tips de viaje específicos
+  async findTravelTips() {
+    const abuDhabi = await strapi.entityService.findMany('api::abu-dhabi.abu-dhabi', {
+      filters: { active: true }
+    });
+
+    return abuDhabi.map(item => ({
+      id: item.id,
+      travelTips: item.travelTips,
+      travelTipsTitle: item.travelTipsTitle
+    }));
+  },
+
+  // Método para obtener características específicas
+  async findFeatures() {
+    const abuDhabi = await strapi.entityService.findMany('api::abu-dhabi.abu-dhabi', {
+      filters: { active: true }
+    });
+
+    return abuDhabi.map(item => ({
+      id: item.id,
+      features: item.features,
+      featuresTitle: item.featuresTitle
+    }));
+  },
+
+  // Método para obtener información de programas
+  async findPrograms() {
+    const abuDhabi = await strapi.entityService.findMany('api::abu-dhabi.abu-dhabi', {
+      filters: { active: true }
+    });
+
+    return abuDhabi.map(item => ({
+      id: item.id,
+      programs: item.programs,
+      requirements: item.requirements
+    }));
+  }
+}));

--- a/src/api/australia/content-types/australia/schema.json
+++ b/src/api/australia/content-types/australia/schema.json
@@ -1,0 +1,209 @@
+{
+  "kind": "collectionType",
+  "collectionName": "australias",
+  "info": {
+    "singularName": "australia",
+    "pluralName": "australias",
+    "displayName": "Australia",
+    "description": "Información detallada sobre Australia como destino de estudio y trabajo"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "title": {
+      "type": "string",
+      "required": true,
+      "maxLength": 255,
+      "default": "Australia"
+    },
+    "slug": {
+      "type": "uid",
+      "targetField": "title",
+      "required": true
+    },
+    "description": {
+      "type": "richtext",
+      "required": true
+    },
+    "shortDescription": {
+      "type": "text",
+      "maxLength": 500
+    },
+    "image": {
+      "type": "media",
+      "multiple": false,
+      "required": true,
+      "allowedTypes": ["images"]
+    },
+    "gallery": {
+      "type": "media",
+      "multiple": true,
+      "allowedTypes": ["images"]
+    },
+    "whyChooseTitle": {
+      "type": "string",
+      "default": "¿Por qué elegir Australia?"
+    },
+    "whyChooseItems": {
+      "type": "json"
+    },
+    "hospitalityTitle": {
+      "type": "string",
+      "default": "Educación de Clase Mundial"
+    },
+    "hospitalityDescription": {
+      "type": "string",
+      "default": "Universidades de prestigio internacional"
+    },
+    "hospitalityIcon": {
+      "type": "string",
+      "default": "🎓"
+    },
+    "educationTitle": {
+      "type": "string",
+      "default": "Calidad de Vida"
+    },
+    "educationDescription": {
+      "type": "string",
+      "default": "Uno de los mejores países para vivir en el mundo"
+    },
+    "educationIcon": {
+      "type": "string",
+      "default": "🏠"
+    },
+    "cultureTitle": {
+      "type": "string",
+      "default": "Cultura Única"
+    },
+    "cultureDescription": {
+      "type": "string",
+      "default": "Mezcla única de culturas europeas e indígenas"
+    },
+    "cultureIcon": {
+      "type": "string",
+      "default": "🌏"
+    },
+    "languageTitle": {
+      "type": "string",
+      "default": "Idioma Inglés"
+    },
+    "languageDescription": {
+      "type": "string",
+      "default": "Inglés como idioma oficial en un entorno multicultural"
+    },
+    "languageIcon": {
+      "type": "string",
+      "default": "🗣️"
+    },
+    "qualityTitle": {
+      "type": "string",
+      "default": "Naturaleza Única"
+    },
+    "qualityDescription": {
+      "type": "string",
+      "default": "Fauna y flora únicas en el mundo"
+    },
+    "qualityIcon": {
+      "type": "string",
+      "default": "🦘"
+    },
+    "opportunitiesTitle": {
+      "type": "string",
+      "default": "Oportunidades Profesionales"
+    },
+    "opportunitiesDescription": {
+      "type": "string",
+      "default": "Carrera en empresas multinacionales y startups"
+    },
+    "opportunitiesIcon": {
+      "type": "string",
+      "default": "💼"
+    },
+    "statisticsTitle": {
+      "type": "string",
+      "default": "Australia en números"
+    },
+    "statistics": {
+      "type": "json"
+    },
+    "featuresTitle": {
+      "type": "string",
+      "default": "Características de Australia"
+    },
+    "features": {
+      "type": "json"
+    },
+    "travelTipsTitle": {
+      "type": "string",
+      "default": "Tips de viaje para Australia"
+    },
+    "travelTips": {
+      "type": "json"
+    },
+    "programs": {
+      "type": "json"
+    },
+    "requirements": {
+      "type": "json"
+    },
+    "overview": {
+      "type": "json"
+    },
+    "highlights": {
+      "type": "json"
+    },
+    "pricing": {
+      "type": "json"
+    },
+    "accommodation": {
+      "type": "json"
+    },
+    "transportation": {
+      "type": "json"
+    },
+    "climate": {
+      "type": "json"
+    },
+    "culture": {
+      "type": "json"
+    },
+    "education": {
+      "type": "json"
+    },
+    "workOpportunities": {
+      "type": "json"
+    },
+    "visaInfo": {
+      "type": "json"
+    },
+    "costOfLiving": {
+      "type": "json"
+    },
+    "safety": {
+      "type": "json"
+    },
+    "attractions": {
+      "type": "json"
+    },
+    "events": {
+      "type": "json"
+    },
+    "testimonials": {
+      "type": "json"
+    },
+    "faq": {
+      "type": "json"
+    },
+    "seoTitle": {
+      "type": "string"
+    },
+    "seoDescription": {
+      "type": "text"
+    },
+    "seoKeywords": {
+      "type": "json"
+    }
+  }
+}

--- a/src/api/australia/controllers/australia.js
+++ b/src/api/australia/controllers/australia.js
@@ -1,0 +1,94 @@
+'use strict';
+
+/**
+ * australia controller
+ */
+
+const { createCoreController } = require('@strapi/strapi').factories;
+
+module.exports = createCoreController('api::australia.australia', ({ strapi }) => ({
+  // Método personalizado para obtener información completa de Australia
+  async findComplete(ctx) {
+    const entities = await strapi.entityService.findMany('api::australia.australia', {
+      filters: { active: true },
+      populate: {
+        image: true,
+        gallery: true
+      }
+    });
+
+    return entities;
+  },
+
+  // Método personalizado para obtener estadísticas de Australia
+  async findStats(ctx) {
+    const entities = await strapi.entityService.findMany('api::australia.australia', {
+      filters: { active: true },
+      populate: {
+        image: true
+      }
+    });
+
+    // Retornar solo las estadísticas
+    return entities.map(entity => ({
+      id: entity.id,
+      title: entity.title,
+      statistics: entity.statistics,
+      statisticsTitle: entity.statisticsTitle
+    }));
+  },
+
+  // Método personalizado para obtener tips de viaje
+  async findTravelTips(ctx) {
+    const entities = await strapi.entityService.findMany('api::australia.australia', {
+      filters: { active: true },
+      populate: {
+        image: true
+      }
+    });
+
+    // Retornar solo los tips de viaje
+    return entities.map(entity => ({
+      id: entity.id,
+      title: entity.title,
+      travelTips: entity.travelTips,
+      travelTipsTitle: entity.travelTipsTitle
+    }));
+  },
+
+  // Método personalizado para obtener características de Australia
+  async findFeatures(ctx) {
+    const entities = await strapi.entityService.findMany('api::australia.australia', {
+      filters: { active: true },
+      populate: {
+        image: true
+      }
+    });
+
+    // Retornar solo las características
+    return entities.map(entity => ({
+      id: entity.id,
+      title: entity.title,
+      features: entity.features,
+      featuresTitle: entity.featuresTitle
+    }));
+  },
+
+  // Método personalizado para obtener información de programas
+  async findPrograms(ctx) {
+    const entities = await strapi.entityService.findMany('api::australia.australia', {
+      filters: { active: true },
+      populate: {
+        image: true
+      }
+    });
+
+    // Retornar solo la información de programas
+    return entities.map(entity => ({
+      id: entity.id,
+      title: entity.title,
+      programs: entity.programs,
+      requirements: entity.requirements
+    }));
+  }
+}));

--- a/src/api/australia/routes/australia.js
+++ b/src/api/australia/routes/australia.js
@@ -1,0 +1,37 @@
+'use strict';
+
+/**
+ * australia router
+ */
+
+const { createCoreRouter } = require('@strapi/strapi').factories;
+
+module.exports = createCoreRouter('api::australia.australia', {
+  config: {
+    find: {
+      auth: false,
+      policies: [],
+      middlewares: [],
+    },
+    findOne: {
+      auth: false,
+      policies: [],
+      middlewares: [],
+    },
+    create: {
+      auth: {
+        strategy: 'jwt',
+      },
+    },
+    update: {
+      auth: {
+        strategy: 'jwt',
+      },
+    },
+    delete: {
+      auth: {
+        strategy: 'jwt',
+      },
+    },
+  },
+});

--- a/src/api/australia/routes/custom-routes.js
+++ b/src/api/australia/routes/custom-routes.js
@@ -1,0 +1,50 @@
+'use strict';
+
+/**
+ * Custom routes for australia
+ */
+
+module.exports = {
+  routes: [
+    {
+      method: 'GET',
+      path: '/australias/complete',
+      handler: 'australia.findComplete',
+      config: {
+        auth: false,
+      },
+    },
+    {
+      method: 'GET',
+      path: '/australias/stats',
+      handler: 'australia.findStats',
+      config: {
+        auth: false,
+      },
+    },
+    {
+      method: 'GET',
+      path: '/australias/travel-tips',
+      handler: 'australia.findTravelTips',
+      config: {
+        auth: false,
+      },
+    },
+    {
+      method: 'GET',
+      path: '/australias/features',
+      handler: 'australia.findFeatures',
+      config: {
+        auth: false,
+      },
+    },
+    {
+      method: 'GET',
+      path: '/australias/programs',
+      handler: 'australia.findPrograms',
+      config: {
+        auth: false,
+      },
+    },
+  ],
+};

--- a/src/api/australia/services/australia.js
+++ b/src/api/australia/services/australia.js
@@ -1,0 +1,74 @@
+'use strict';
+
+/**
+ * australia service
+ */
+
+const { createCoreService } = require('@strapi/strapi').factories;
+
+module.exports = createCoreService('api::australia.australia', ({ strapi }) => ({
+  // Método personalizado para obtener información completa de Australia
+  async findCompleteInfo() {
+    const australia = await strapi.entityService.findMany('api::australia.australia', {
+      filters: { active: true },
+      populate: {
+        image: true,
+        gallery: true
+      }
+    });
+
+    return australia;
+  },
+
+  // Método para obtener estadísticas específicas
+  async findStatistics() {
+    const australia = await strapi.entityService.findMany('api::australia.australia', {
+      filters: { active: true }
+    });
+
+    return australia.map(item => ({
+      id: item.id,
+      statistics: item.statistics,
+      statisticsTitle: item.statisticsTitle
+    }));
+  },
+
+  // Método para obtener tips de viaje específicos
+  async findTravelTips() {
+    const australia = await strapi.entityService.findMany('api::australia.australia', {
+      filters: { active: true }
+    });
+
+    return australia.map(item => ({
+      id: item.id,
+      travelTips: item.travelTips,
+      travelTipsTitle: item.travelTipsTitle
+    }));
+  },
+
+  // Método para obtener características específicas
+  async findFeatures() {
+    const australia = await strapi.entityService.findMany('api::australia.australia', {
+      filters: { active: true }
+    });
+
+    return australia.map(item => ({
+      id: item.id,
+      features: item.features,
+      featuresTitle: item.featuresTitle
+    }));
+  },
+
+  // Método para obtener información de programas
+  async findPrograms() {
+    const australia = await strapi.entityService.findMany('api::australia.australia', {
+      filters: { active: true }
+    });
+
+    return australia.map(item => ({
+      id: item.id,
+      programs: item.programs,
+      requirements: item.requirements
+    }));
+  }
+}));

--- a/src/api/canada/content-types/canada/schema.json
+++ b/src/api/canada/content-types/canada/schema.json
@@ -1,0 +1,209 @@
+{
+  "kind": "collectionType",
+  "collectionName": "canadas",
+  "info": {
+    "singularName": "canada",
+    "pluralName": "canadas",
+    "displayName": "Canada",
+    "description": "Información detallada sobre Canadá como destino de estudio y trabajo"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "title": {
+      "type": "string",
+      "required": true,
+      "maxLength": 255,
+      "default": "Canada"
+    },
+    "slug": {
+      "type": "uid",
+      "targetField": "title",
+      "required": true
+    },
+    "description": {
+      "type": "richtext",
+      "required": true
+    },
+    "shortDescription": {
+      "type": "text",
+      "maxLength": 500
+    },
+    "image": {
+      "type": "media",
+      "multiple": false,
+      "required": true,
+      "allowedTypes": ["images"]
+    },
+    "gallery": {
+      "type": "media",
+      "multiple": true,
+      "allowedTypes": ["images"]
+    },
+    "whyChooseTitle": {
+      "type": "string",
+      "default": "¿Por qué elegir Canadá?"
+    },
+    "whyChooseItems": {
+      "type": "json"
+    },
+    "hospitalityTitle": {
+      "type": "string",
+      "default": "Educación de Excelencia"
+    },
+    "hospitalityDescription": {
+      "type": "string",
+      "default": "Universidades de prestigio mundial con costos accesibles"
+    },
+    "hospitalityIcon": {
+      "type": "string",
+      "default": "🎓"
+    },
+    "educationTitle": {
+      "type": "string",
+      "default": "Multiculturalismo"
+    },
+    "educationDescription": {
+      "type": "string",
+      "default": "País que celebra la diversidad cultural"
+    },
+    "educationIcon": {
+      "type": "string",
+      "default": "🌍"
+    },
+    "cultureTitle": {
+      "type": "string",
+      "default": "Calidad de Vida"
+    },
+    "cultureDescription": {
+      "type": "string",
+      "default": "Uno de los mejores países para vivir en el mundo"
+    },
+    "cultureIcon": {
+      "type": "string",
+      "default": "🏠"
+    },
+    "languageTitle": {
+      "type": "string",
+      "default": "Idiomas Oficiales"
+    },
+    "languageDescription": {
+      "type": "string",
+      "default": "Inglés y francés como idiomas oficiales"
+    },
+    "languageIcon": {
+      "type": "string",
+      "default": "🗣️"
+    },
+    "qualityTitle": {
+      "type": "string",
+      "default": "Naturaleza Única"
+    },
+    "qualityDescription": {
+      "type": "string",
+      "default": "Desde montañas hasta océanos, naturaleza espectacular"
+    },
+    "qualityIcon": {
+      "type": "string",
+      "default": "🏔️"
+    },
+    "opportunitiesTitle": {
+      "type": "string",
+      "default": "Oportunidades Profesionales"
+    },
+    "opportunitiesDescription": {
+      "type": "string",
+      "default": "Carrera en empresas multinacionales y startups"
+    },
+    "opportunitiesIcon": {
+      "type": "string",
+      "default": "💼"
+    },
+    "statisticsTitle": {
+      "type": "string",
+      "default": "Canadá en números"
+    },
+    "statistics": {
+      "type": "json"
+    },
+    "featuresTitle": {
+      "type": "string",
+      "default": "Características de Canadá"
+    },
+    "features": {
+      "type": "json"
+    },
+    "travelTipsTitle": {
+      "type": "string",
+      "default": "Tips de viaje para Canadá"
+    },
+    "travelTips": {
+      "type": "json"
+    },
+    "programs": {
+      "type": "json"
+    },
+    "requirements": {
+      "type": "json"
+    },
+    "overview": {
+      "type": "json"
+    },
+    "highlights": {
+      "type": "json"
+    },
+    "pricing": {
+      "type": "json"
+    },
+    "accommodation": {
+      "type": "json"
+    },
+    "transportation": {
+      "type": "json"
+    },
+    "climate": {
+      "type": "json"
+    },
+    "culture": {
+      "type": "json"
+    },
+    "education": {
+      "type": "json"
+    },
+    "workOpportunities": {
+      "type": "json"
+    },
+    "visaInfo": {
+      "type": "json"
+    },
+    "costOfLiving": {
+      "type": "json"
+    },
+    "safety": {
+      "type": "json"
+    },
+    "attractions": {
+      "type": "json"
+    },
+    "events": {
+      "type": "json"
+    },
+    "testimonials": {
+      "type": "json"
+    },
+    "faq": {
+      "type": "json"
+    },
+    "seoTitle": {
+      "type": "string"
+    },
+    "seoDescription": {
+      "type": "text"
+    },
+    "seoKeywords": {
+      "type": "json"
+    }
+  }
+}

--- a/src/api/canada/controllers/canada.js
+++ b/src/api/canada/controllers/canada.js
@@ -1,0 +1,94 @@
+'use strict';
+
+/**
+ * canada controller
+ */
+
+const { createCoreController } = require('@strapi/strapi').factories;
+
+module.exports = createCoreController('api::canada.canada', ({ strapi }) => ({
+  // Método personalizado para obtener información completa de Canadá
+  async findComplete(ctx) {
+    const entities = await strapi.entityService.findMany('api::canada.canada', {
+      filters: { active: true },
+      populate: {
+        image: true,
+        gallery: true
+      }
+    });
+
+    return entities;
+  },
+
+  // Método personalizado para obtener estadísticas de Canadá
+  async findStats(ctx) {
+    const entities = await strapi.entityService.findMany('api::canada.canada', {
+      filters: { active: true },
+      populate: {
+        image: true
+      }
+    });
+
+    // Retornar solo las estadísticas
+    return entities.map(entity => ({
+      id: entity.id,
+      title: entity.title,
+      statistics: entity.statistics,
+      statisticsTitle: entity.statisticsTitle
+    }));
+  },
+
+  // Método personalizado para obtener tips de viaje
+  async findTravelTips(ctx) {
+    const entities = await strapi.entityService.findMany('api::canada.canada', {
+      filters: { active: true },
+      populate: {
+        image: true
+      }
+    });
+
+    // Retornar solo los tips de viaje
+    return entities.map(entity => ({
+      id: entity.id,
+      title: entity.title,
+      travelTips: entity.travelTips,
+      travelTipsTitle: entity.travelTipsTitle
+    }));
+  },
+
+  // Método personalizado para obtener características de Canadá
+  async findFeatures(ctx) {
+    const entities = await strapi.entityService.findMany('api::canada.canada', {
+      filters: { active: true },
+      populate: {
+        image: true
+      }
+    });
+
+    // Retornar solo las características
+    return entities.map(entity => ({
+      id: entity.id,
+      title: entity.title,
+      features: entity.features,
+      featuresTitle: entity.featuresTitle
+    }));
+  },
+
+  // Método personalizado para obtener información de programas
+  async findPrograms(ctx) {
+    const entities = await strapi.entityService.findMany('api::canada.canada', {
+      filters: { active: true },
+      populate: {
+        image: true
+      }
+    });
+
+    // Retornar solo la información de programas
+    return entities.map(entity => ({
+      id: entity.id,
+      title: entity.title,
+      programs: entity.programs,
+      requirements: entity.requirements
+    }));
+  }
+}));

--- a/src/api/canada/routes/canada.js
+++ b/src/api/canada/routes/canada.js
@@ -1,0 +1,37 @@
+'use strict';
+
+/**
+ * canada router
+ */
+
+const { createCoreRouter } = require('@strapi/strapi').factories;
+
+module.exports = createCoreRouter('api::canada.canada', {
+  config: {
+    find: {
+      auth: false,
+      policies: [],
+      middlewares: [],
+    },
+    findOne: {
+      auth: false,
+      policies: [],
+      middlewares: [],
+    },
+    create: {
+      auth: {
+        strategy: 'jwt',
+      },
+    },
+    update: {
+      auth: {
+        strategy: 'jwt',
+      },
+    },
+    delete: {
+      auth: {
+        strategy: 'jwt',
+      },
+    },
+  },
+});

--- a/src/api/canada/routes/custom-routes.js
+++ b/src/api/canada/routes/custom-routes.js
@@ -1,0 +1,50 @@
+'use strict';
+
+/**
+ * Custom routes for canada
+ */
+
+module.exports = {
+  routes: [
+    {
+      method: 'GET',
+      path: '/canadas/complete',
+      handler: 'canada.findComplete',
+      config: {
+        auth: false,
+      },
+    },
+    {
+      method: 'GET',
+      path: '/canadas/stats',
+      handler: 'canada.findStats',
+      config: {
+        auth: false,
+      },
+    },
+    {
+      method: 'GET',
+      path: '/canadas/travel-tips',
+      handler: 'canada.findTravelTips',
+      config: {
+        auth: false,
+      },
+    },
+    {
+      method: 'GET',
+      path: '/canadas/features',
+      handler: 'canada.findFeatures',
+      config: {
+        auth: false,
+      },
+    },
+    {
+      method: 'GET',
+      path: '/canadas/programs',
+      handler: 'canada.findPrograms',
+      config: {
+        auth: false,
+      },
+    },
+  ],
+};

--- a/src/api/canada/services/canada.js
+++ b/src/api/canada/services/canada.js
@@ -1,0 +1,74 @@
+'use strict';
+
+/**
+ * canada service
+ */
+
+const { createCoreService } = require('@strapi/strapi').factories;
+
+module.exports = createCoreService('api::canada.canada', ({ strapi }) => ({
+  // Método personalizado para obtener información completa de Canadá
+  async findCompleteInfo() {
+    const canada = await strapi.entityService.findMany('api::canada.canada', {
+      filters: { active: true },
+      populate: {
+        image: true,
+        gallery: true
+      }
+    });
+
+    return canada;
+  },
+
+  // Método para obtener estadísticas específicas
+  async findStatistics() {
+    const canada = await strapi.entityService.findMany('api::canada.canada', {
+      filters: { active: true }
+    });
+
+    return canada.map(item => ({
+      id: item.id,
+      statistics: item.statistics,
+      statisticsTitle: item.statisticsTitle
+    }));
+  },
+
+  // Método para obtener tips de viaje específicos
+  async findTravelTips() {
+    const canada = await strapi.entityService.findMany('api::canada.canada', {
+      filters: { active: true }
+    });
+
+    return canada.map(item => ({
+      id: item.id,
+      travelTips: item.travelTips,
+      travelTipsTitle: item.travelTipsTitle
+    }));
+  },
+
+  // Método para obtener características específicas
+  async findFeatures() {
+    const canada = await strapi.entityService.findMany('api::canada.canada', {
+      filters: { active: true }
+    });
+
+    return canada.map(item => ({
+      id: item.id,
+      features: item.features,
+      featuresTitle: item.featuresTitle
+    }));
+  },
+
+  // Método para obtener información de programas
+  async findPrograms() {
+    const canada = await strapi.entityService.findMany('api::canada.canada', {
+      filters: { active: true }
+    });
+
+    return canada.map(item => ({
+      id: item.id,
+      programs: item.programs,
+      requirements: item.requirements
+    }));
+  }
+}));

--- a/src/api/dubai/content-types/dubai/schema.json
+++ b/src/api/dubai/content-types/dubai/schema.json
@@ -1,0 +1,209 @@
+{
+  "kind": "collectionType",
+  "collectionName": "dubais",
+  "info": {
+    "singularName": "dubai",
+    "pluralName": "dubais",
+    "displayName": "Dubai",
+    "description": "Información detallada sobre Dubai como destino de estudio y trabajo"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "title": {
+      "type": "string",
+      "required": true,
+      "maxLength": 255,
+      "default": "Dubai"
+    },
+    "slug": {
+      "type": "uid",
+      "targetField": "title",
+      "required": true
+    },
+    "description": {
+      "type": "richtext",
+      "required": true
+    },
+    "shortDescription": {
+      "type": "text",
+      "maxLength": 500
+    },
+    "image": {
+      "type": "media",
+      "multiple": false,
+      "required": true,
+      "allowedTypes": ["images"]
+    },
+    "gallery": {
+      "type": "media",
+      "multiple": true,
+      "allowedTypes": ["images"]
+    },
+    "whyChooseTitle": {
+      "type": "string",
+      "default": "¿Por qué elegir Dubai?"
+    },
+    "whyChooseItems": {
+      "type": "json"
+    },
+    "hospitalityTitle": {
+      "type": "string",
+      "default": "Centro Comercial Global"
+    },
+    "hospitalityDescription": {
+      "type": "string",
+      "default": "Hub de negocios y comercio en el Medio Oriente"
+    },
+    "hospitalityIcon": {
+      "type": "string",
+      "default": "🏢"
+    },
+    "educationTitle": {
+      "type": "string",
+      "default": "Educación Internacional"
+    },
+    "educationDescription": {
+      "type": "string",
+      "default": "Universidades de prestigio mundial"
+    },
+    "educationIcon": {
+      "type": "string",
+      "default": "🎓"
+    },
+    "cultureTitle": {
+      "type": "string",
+      "default": "Fusión Cultural"
+    },
+    "cultureDescription": {
+      "type": "string",
+      "default": "Mezcla única de tradición árabe y modernidad"
+    },
+    "cultureIcon": {
+      "type": "string",
+      "default": "🌏"
+    },
+    "languageTitle": {
+      "type": "string",
+      "default": "Idiomas Múltiples"
+    },
+    "languageDescription": {
+      "type": "string",
+      "default": "Árabe, inglés y más de 200 idiomas"
+    },
+    "languageIcon": {
+      "type": "string",
+      "default": "🗣️"
+    },
+    "qualityTitle": {
+      "type": "string",
+      "default": "Lujo y Modernidad"
+    },
+    "qualityDescription": {
+      "type": "string",
+      "default": "Infraestructura de clase mundial"
+    },
+    "qualityIcon": {
+      "type": "string",
+      "default": "🏙️"
+    },
+    "opportunitiesTitle": {
+      "type": "string",
+      "default": "Oportunidades Profesionales"
+    },
+    "opportunitiesDescription": {
+      "type": "string",
+      "default": "Carrera en empresas multinacionales y startups"
+    },
+    "opportunitiesIcon": {
+      "type": "string",
+      "default": "💼"
+    },
+    "statisticsTitle": {
+      "type": "string",
+      "default": "Dubai en números"
+    },
+    "statistics": {
+      "type": "json"
+    },
+    "featuresTitle": {
+      "type": "string",
+      "default": "Características de Dubai"
+    },
+    "features": {
+      "type": "json"
+    },
+    "travelTipsTitle": {
+      "type": "string",
+      "default": "Tips de viaje para Dubai"
+    },
+    "travelTips": {
+      "type": "json"
+    },
+    "programs": {
+      "type": "json"
+    },
+    "requirements": {
+      "type": "json"
+    },
+    "overview": {
+      "type": "json"
+    },
+    "highlights": {
+      "type": "json"
+    },
+    "pricing": {
+      "type": "json"
+    },
+    "accommodation": {
+      "type": "json"
+    },
+    "transportation": {
+      "type": "json"
+    },
+    "climate": {
+      "type": "json"
+    },
+    "culture": {
+      "type": "json"
+    },
+    "education": {
+      "type": "json"
+    },
+    "workOpportunities": {
+      "type": "json"
+    },
+    "visaInfo": {
+      "type": "json"
+    },
+    "costOfLiving": {
+      "type": "json"
+    },
+    "safety": {
+      "type": "json"
+    },
+    "attractions": {
+      "type": "json"
+    },
+    "events": {
+      "type": "json"
+    },
+    "testimonials": {
+      "type": "json"
+    },
+    "faq": {
+      "type": "json"
+    },
+    "seoTitle": {
+      "type": "string"
+    },
+    "seoDescription": {
+      "type": "text"
+    },
+    "seoKeywords": {
+      "type": "json"
+    }
+  }
+}

--- a/src/api/dubai/controllers/dubai.js
+++ b/src/api/dubai/controllers/dubai.js
@@ -1,0 +1,94 @@
+'use strict';
+
+/**
+ * dubai controller
+ */
+
+const { createCoreController } = require('@strapi/strapi').factories;
+
+module.exports = createCoreController('api::dubai.dubai', ({ strapi }) => ({
+  // Método personalizado para obtener información completa de Dubai
+  async findComplete(ctx) {
+    const entities = await strapi.entityService.findMany('api::dubai.dubai', {
+      filters: { active: true },
+      populate: {
+        image: true,
+        gallery: true
+      }
+    });
+
+    return entities;
+  },
+
+  // Método personalizado para obtener estadísticas de Dubai
+  async findStats(ctx) {
+    const entities = await strapi.entityService.findMany('api::dubai.dubai', {
+      filters: { active: true },
+      populate: {
+        image: true
+      }
+    });
+
+    // Retornar solo las estadísticas
+    return entities.map(entity => ({
+      id: entity.id,
+      title: entity.title,
+      statistics: entity.statistics,
+      statisticsTitle: entity.statisticsTitle
+    }));
+  },
+
+  // Método personalizado para obtener tips de viaje
+  async findTravelTips(ctx) {
+    const entities = await strapi.entityService.findMany('api::dubai.dubai', {
+      filters: { active: true },
+      populate: {
+        image: true
+      }
+    });
+
+    // Retornar solo los tips de viaje
+    return entities.map(entity => ({
+      id: entity.id,
+      title: entity.title,
+      travelTips: entity.travelTips,
+      travelTipsTitle: entity.travelTipsTitle
+    }));
+  },
+
+  // Método personalizado para obtener características de Dubai
+  async findFeatures(ctx) {
+    const entities = await strapi.entityService.findMany('api::dubai.dubai', {
+      filters: { active: true },
+      populate: {
+        image: true
+      }
+    });
+
+    // Retornar solo las características
+    return entities.map(entity => ({
+      id: entity.id,
+      title: entity.title,
+      features: entity.features,
+      featuresTitle: entity.featuresTitle
+    }));
+  },
+
+  // Método personalizado para obtener información de programas
+  async findPrograms(ctx) {
+    const entities = await strapi.entityService.findMany('api::dubai.dubai', {
+      filters: { active: true },
+      populate: {
+        image: true
+      }
+    });
+
+    // Retornar solo la información de programas
+    return entities.map(entity => ({
+      id: entity.id,
+      title: entity.title,
+      programs: entity.programs,
+      requirements: entity.requirements
+    }));
+  }
+}));

--- a/src/api/dubai/routes/custom-routes.js
+++ b/src/api/dubai/routes/custom-routes.js
@@ -1,0 +1,50 @@
+'use strict';
+
+/**
+ * Custom routes for dubai
+ */
+
+module.exports = {
+  routes: [
+    {
+      method: 'GET',
+      path: '/dubais/complete',
+      handler: 'dubai.findComplete',
+      config: {
+        auth: false,
+      },
+    },
+    {
+      method: 'GET',
+      path: '/dubais/stats',
+      handler: 'dubai.findStats',
+      config: {
+        auth: false,
+      },
+    },
+    {
+      method: 'GET',
+      path: '/dubais/travel-tips',
+      handler: 'dubai.findTravelTips',
+      config: {
+        auth: false,
+      },
+    },
+    {
+      method: 'GET',
+      path: '/dubais/features',
+      handler: 'dubai.findFeatures',
+      config: {
+        auth: false,
+      },
+    },
+    {
+      method: 'GET',
+      path: '/dubais/programs',
+      handler: 'dubai.findPrograms',
+      config: {
+        auth: false,
+      },
+    },
+  ],
+};

--- a/src/api/dubai/routes/dubai.js
+++ b/src/api/dubai/routes/dubai.js
@@ -1,0 +1,37 @@
+'use strict';
+
+/**
+ * dubai router
+ */
+
+const { createCoreRouter } = require('@strapi/strapi').factories;
+
+module.exports = createCoreRouter('api::dubai.dubai', {
+  config: {
+    find: {
+      auth: false,
+      policies: [],
+      middlewares: [],
+    },
+    findOne: {
+      auth: false,
+      policies: [],
+      middlewares: [],
+    },
+    create: {
+      auth: {
+        strategy: 'jwt',
+      },
+    },
+    update: {
+      auth: {
+        strategy: 'jwt',
+      },
+    },
+    delete: {
+      auth: {
+        strategy: 'jwt',
+      },
+    },
+  },
+});

--- a/src/api/dubai/services/dubai.js
+++ b/src/api/dubai/services/dubai.js
@@ -1,0 +1,74 @@
+'use strict';
+
+/**
+ * dubai service
+ */
+
+const { createCoreService } = require('@strapi/strapi').factories;
+
+module.exports = createCoreService('api::dubai.dubai', ({ strapi }) => ({
+  // Método personalizado para obtener información completa de Dubai
+  async findCompleteInfo() {
+    const dubai = await strapi.entityService.findMany('api::dubai.dubai', {
+      filters: { active: true },
+      populate: {
+        image: true,
+        gallery: true
+      }
+    });
+
+    return dubai;
+  },
+
+  // Método para obtener estadísticas específicas
+  async findStatistics() {
+    const dubai = await strapi.entityService.findMany('api::dubai.dubai', {
+      filters: { active: true }
+    });
+
+    return dubai.map(item => ({
+      id: item.id,
+      statistics: item.statistics,
+      statisticsTitle: item.statisticsTitle
+    }));
+  },
+
+  // Método para obtener tips de viaje específicos
+  async findTravelTips() {
+    const dubai = await strapi.entityService.findMany('api::dubai.dubai', {
+      filters: { active: true }
+    });
+
+    return dubai.map(item => ({
+      id: item.id,
+      travelTips: item.travelTips,
+      travelTipsTitle: item.travelTipsTitle
+    }));
+  },
+
+  // Método para obtener características específicas
+  async findFeatures() {
+    const dubai = await strapi.entityService.findMany('api::dubai.dubai', {
+      filters: { active: true }
+    });
+
+    return dubai.map(item => ({
+      id: item.id,
+      features: item.features,
+      featuresTitle: item.featuresTitle
+    }));
+  },
+
+  // Método para obtener información de programas
+  async findPrograms() {
+    const dubai = await strapi.entityService.findMany('api::dubai.dubai', {
+      filters: { active: true }
+    });
+
+    return dubai.map(item => ({
+      id: item.id,
+      programs: item.programs,
+      requirements: item.requirements
+    }));
+  }
+}));

--- a/src/api/hong-kong/content-types/hong-kong/schema.json
+++ b/src/api/hong-kong/content-types/hong-kong/schema.json
@@ -1,0 +1,209 @@
+{
+  "kind": "collectionType",
+  "collectionName": "hong_kongs",
+  "info": {
+    "singularName": "hong-kong",
+    "pluralName": "hong-kongs",
+    "displayName": "Hong Kong",
+    "description": "Información detallada sobre Hong Kong como destino de estudio y trabajo"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "title": {
+      "type": "string",
+      "required": true,
+      "maxLength": 255,
+      "default": "Hong Kong"
+    },
+    "slug": {
+      "type": "uid",
+      "targetField": "title",
+      "required": true
+    },
+    "description": {
+      "type": "richtext",
+      "required": true
+    },
+    "shortDescription": {
+      "type": "text",
+      "maxLength": 500
+    },
+    "image": {
+      "type": "media",
+      "multiple": false,
+      "required": true,
+      "allowedTypes": ["images"]
+    },
+    "gallery": {
+      "type": "media",
+      "multiple": true,
+      "allowedTypes": ["images"]
+    },
+    "whyChooseTitle": {
+      "type": "string",
+      "default": "¿Por qué elegir Hong Kong?"
+    },
+    "whyChooseItems": {
+      "type": "json"
+    },
+    "hospitalityTitle": {
+      "type": "string",
+      "default": "Centro Financiero Global"
+    },
+    "hospitalityDescription": {
+      "type": "string",
+      "default": "Oportunidades en el corazón financiero de Asia"
+    },
+    "hospitalityIcon": {
+      "type": "string",
+      "default": "🏦"
+    },
+    "educationTitle": {
+      "type": "string",
+      "default": "Educación de Clase Mundial"
+    },
+    "educationDescription": {
+      "type": "string",
+      "default": "Universidades de prestigio internacional"
+    },
+    "educationIcon": {
+      "type": "string",
+      "default": "🎓"
+    },
+    "cultureTitle": {
+      "type": "string",
+      "default": "Fusión Cultural"
+    },
+    "cultureDescription": {
+      "type": "string",
+      "default": "Mezcla única de tradición china y modernidad occidental"
+    },
+    "cultureIcon": {
+      "type": "string",
+      "default": "🌏"
+    },
+    "languageTitle": {
+      "type": "string",
+      "default": "Idiomas Múltiples"
+    },
+    "languageDescription": {
+      "type": "string",
+      "default": "Inglés, cantonés y mandarín en un solo lugar"
+    },
+    "languageIcon": {
+      "type": "string",
+      "default": "🗣️"
+    },
+    "qualityTitle": {
+      "type": "string",
+      "default": "Calidad de Vida"
+    },
+    "qualityDescription": {
+      "type": "string",
+      "default": "Infraestructura moderna y servicios de primera"
+    },
+    "qualityIcon": {
+      "type": "string",
+      "default": "🏙️"
+    },
+    "opportunitiesTitle": {
+      "type": "string",
+      "default": "Oportunidades Profesionales"
+    },
+    "opportunitiesDescription": {
+      "type": "string",
+      "default": "Carrera en empresas multinacionales y startups"
+    },
+    "opportunitiesIcon": {
+      "type": "string",
+      "default": "💼"
+    },
+    "statisticsTitle": {
+      "type": "string",
+      "default": "Hong Kong en números"
+    },
+    "statistics": {
+      "type": "json"
+    },
+    "featuresTitle": {
+      "type": "string",
+      "default": "Características de Hong Kong"
+    },
+    "features": {
+      "type": "json"
+    },
+    "travelTipsTitle": {
+      "type": "string",
+      "default": "Tips de viaje para Hong Kong"
+    },
+    "travelTips": {
+      "type": "json"
+    },
+    "programs": {
+      "type": "json"
+    },
+    "requirements": {
+      "type": "json"
+    },
+    "overview": {
+      "type": "json"
+    },
+    "highlights": {
+      "type": "json"
+    },
+    "pricing": {
+      "type": "json"
+    },
+    "accommodation": {
+      "type": "json"
+    },
+    "transportation": {
+      "type": "json"
+    },
+    "climate": {
+      "type": "json"
+    },
+    "culture": {
+      "type": "json"
+    },
+    "education": {
+      "type": "json"
+    },
+    "workOpportunities": {
+      "type": "json"
+    },
+    "visaInfo": {
+      "type": "json"
+    },
+    "costOfLiving": {
+      "type": "json"
+    },
+    "safety": {
+      "type": "json"
+    },
+    "attractions": {
+      "type": "json"
+    },
+    "events": {
+      "type": "json"
+    },
+    "testimonials": {
+      "type": "json"
+    },
+    "faq": {
+      "type": "json"
+    },
+    "seoTitle": {
+      "type": "string"
+    },
+    "seoDescription": {
+      "type": "text"
+    },
+    "seoKeywords": {
+      "type": "json"
+    }
+  }
+}

--- a/src/api/hong-kong/controllers/hong-kong.js
+++ b/src/api/hong-kong/controllers/hong-kong.js
@@ -1,0 +1,94 @@
+'use strict';
+
+/**
+ * hong-kong controller
+ */
+
+const { createCoreController } = require('@strapi/strapi').factories;
+
+module.exports = createCoreController('api::hong-kong.hong-kong', ({ strapi }) => ({
+  // Método personalizado para obtener información completa de Hong Kong
+  async findComplete(ctx) {
+    const entities = await strapi.entityService.findMany('api::hong-kong.hong-kong', {
+      filters: { active: true },
+      populate: {
+        image: true,
+        gallery: true
+      }
+    });
+
+    return entities;
+  },
+
+  // Método personalizado para obtener estadísticas de Hong Kong
+  async findStats(ctx) {
+    const entities = await strapi.entityService.findMany('api::hong-kong.hong-kong', {
+      filters: { active: true },
+      populate: {
+        image: true
+      }
+    });
+
+    // Retornar solo las estadísticas
+    return entities.map(entity => ({
+      id: entity.id,
+      title: entity.title,
+      statistics: entity.statistics,
+      statisticsTitle: entity.statisticsTitle
+    }));
+  },
+
+  // Método personalizado para obtener tips de viaje
+  async findTravelTips(ctx) {
+    const entities = await strapi.entityService.findMany('api::hong-kong.hong-kong', {
+      filters: { active: true },
+      populate: {
+        image: true
+      }
+    });
+
+    // Retornar solo los tips de viaje
+    return entities.map(entity => ({
+      id: entity.id,
+      title: entity.title,
+      travelTips: entity.travelTips,
+      travelTipsTitle: entity.travelTipsTitle
+    }));
+  },
+
+  // Método personalizado para obtener características de Hong Kong
+  async findFeatures(ctx) {
+    const entities = await strapi.entityService.findMany('api::hong-kong.hong-kong', {
+      filters: { active: true },
+      populate: {
+        image: true
+      }
+    });
+
+    // Retornar solo las características
+    return entities.map(entity => ({
+      id: entity.id,
+      title: entity.title,
+      features: entity.features,
+      featuresTitle: entity.featuresTitle
+    }));
+  },
+
+  // Método personalizado para obtener información de programas
+  async findPrograms(ctx) {
+    const entities = await strapi.entityService.findMany('api::hong-kong.hong-kong', {
+      filters: { active: true },
+      populate: {
+        image: true
+      }
+    });
+
+    // Retornar solo la información de programas
+    return entities.map(entity => ({
+      id: entity.id,
+      title: entity.title,
+      programs: entity.programs,
+      requirements: entity.requirements
+    }));
+  }
+}));

--- a/src/api/hong-kong/routes/custom-routes.js
+++ b/src/api/hong-kong/routes/custom-routes.js
@@ -1,0 +1,50 @@
+'use strict';
+
+/**
+ * Custom routes for hong-kong
+ */
+
+module.exports = {
+  routes: [
+    {
+      method: 'GET',
+      path: '/hong-kongs/complete',
+      handler: 'hong-kong.findComplete',
+      config: {
+        auth: false,
+      },
+    },
+    {
+      method: 'GET',
+      path: '/hong-kongs/stats',
+      handler: 'hong-kong.findStats',
+      config: {
+        auth: false,
+      },
+    },
+    {
+      method: 'GET',
+      path: '/hong-kongs/travel-tips',
+      handler: 'hong-kong.findTravelTips',
+      config: {
+        auth: false,
+      },
+    },
+    {
+      method: 'GET',
+      path: '/hong-kongs/features',
+      handler: 'hong-kong.findFeatures',
+      config: {
+        auth: false,
+      },
+    },
+    {
+      method: 'GET',
+      path: '/hong-kongs/programs',
+      handler: 'hong-kong.findPrograms',
+      config: {
+        auth: false,
+      },
+    },
+  ],
+};

--- a/src/api/hong-kong/routes/hong-kong.js
+++ b/src/api/hong-kong/routes/hong-kong.js
@@ -1,0 +1,37 @@
+'use strict';
+
+/**
+ * hong-kong router
+ */
+
+const { createCoreRouter } = require('@strapi/strapi').factories;
+
+module.exports = createCoreRouter('api::hong-kong.hong-kong', {
+  config: {
+    find: {
+      auth: false,
+      policies: [],
+      middlewares: [],
+    },
+    findOne: {
+      auth: false,
+      policies: [],
+      middlewares: [],
+    },
+    create: {
+      auth: {
+        strategy: 'jwt',
+      },
+    },
+    update: {
+      auth: {
+        strategy: 'jwt',
+      },
+    },
+    delete: {
+      auth: {
+        strategy: 'jwt',
+      },
+    },
+  },
+});

--- a/src/api/hong-kong/sample-data.json
+++ b/src/api/hong-kong/sample-data.json
@@ -1,0 +1,272 @@
+{
+  "hongKongData": [
+    {
+      "title": "Hong Kong",
+      "slug": "hong-kong",
+      "description": "Descubre Hong Kong, el centro financiero de Asia que combina tradición china con modernidad occidental. Oportunidades únicas en finanzas, tecnología, educación y negocios internacionales.",
+      "shortDescription": "Centro financiero global con fusión cultural única",
+      "featured": true,
+      "active": true,
+      "whyChooseTitle": "¿Por qué elegir Hong Kong?",
+      "whyChooseItems": [
+        {
+          "title": "Centro Financiero Global",
+          "description": "Oportunidades en el corazón financiero de Asia",
+          "icon": "🏦"
+        },
+        {
+          "title": "Educación de Clase Mundial",
+          "description": "Universidades de prestigio internacional",
+          "icon": "🎓"
+        },
+        {
+          "title": "Fusión Cultural",
+          "description": "Mezcla única de tradición china y modernidad occidental",
+          "icon": "🌏"
+        },
+        {
+          "title": "Idiomas Múltiples",
+          "description": "Inglés, cantonés y mandarín en un solo lugar",
+          "icon": "🗣️"
+        },
+        {
+          "title": "Calidad de Vida",
+          "description": "Infraestructura moderna y servicios de primera",
+          "icon": "🏙️"
+        },
+        {
+          "title": "Oportunidades Profesionales",
+          "description": "Carrera en empresas multinacionales y startups",
+          "icon": "💼"
+        }
+      ],
+      "statisticsTitle": "Hong Kong en números",
+      "statistics": [
+        {
+          "value": "7.5M+",
+          "label": "Habitantes"
+        },
+        {
+          "value": "3rd",
+          "label": "Centro financiero mundial"
+        },
+        {
+          "value": "95%",
+          "label": "Población urbana"
+        },
+        {
+          "value": "0%",
+          "label": "Impuesto sobre la renta"
+        }
+      ],
+      "featuresTitle": "Características de Hong Kong",
+      "features": [
+        {
+          "title": "Centro Financiero",
+          "description": "Uno de los principales centros financieros del mundo",
+          "icon": "🏦"
+        },
+        {
+          "title": "Educación Internacional",
+          "description": "Universidades de prestigio mundial",
+          "icon": "🎓"
+        },
+        {
+          "title": "Fusión Cultural",
+          "description": "Tradición china y modernidad occidental",
+          "icon": "🌏"
+        },
+        {
+          "title": "Tecnología Avanzada",
+          "description": "Hub tecnológico en Asia",
+          "icon": "💻"
+        }
+      ],
+      "travelTipsTitle": "Tips de viaje para Hong Kong",
+      "travelTips": [
+        {
+          "title": "Visa de Trabajo",
+          "description": "Proceso de visa para profesionales calificados."
+        },
+        {
+          "title": "Cultura Local",
+          "description": "Respeto por las tradiciones chinas y la cultura local."
+        },
+        {
+          "title": "Clima Subtropical",
+          "description": "Preparación para clima húmedo y cálido."
+        },
+        {
+          "title": "Transporte",
+          "description": "Sistema de transporte público eficiente y moderno."
+        }
+      ],
+      "programs": [
+        "work-and-study",
+        "internship",
+        "study-abroad"
+      ],
+      "requirements": [
+        "Nivel de inglés avanzado",
+        "Título universitario",
+        "Experiencia profesional",
+        "Mayor de 21 años"
+      ],
+      "overview": {
+        "highlights": [
+          {
+            "title": "Centro Financiero Global",
+            "description": "Oportunidades en el corazón financiero de Asia",
+            "icon": "Building"
+          },
+          {
+            "title": "Educación de Clase Mundial",
+            "description": "Universidades de prestigio internacional",
+            "icon": "GraduationCap"
+          },
+          {
+            "title": "Fusión Cultural",
+            "description": "Mezcla única de tradición china y modernidad occidental",
+            "icon": "Globe"
+          }
+        ],
+        "features": [
+          {
+            "title": "Idiomas Múltiples",
+            "description": "Inglés, cantonés y mandarín en un solo lugar"
+          },
+          {
+            "title": "Calidad de Vida",
+            "description": "Infraestructura moderna y servicios de primera"
+          },
+          {
+            "title": "Oportunidades Profesionales",
+            "description": "Carrera en empresas multinacionales y startups"
+          }
+        ]
+      },
+      "pricing": {
+        "accommodation": "800-2000 USD/mes",
+        "food": "400-800 USD/mes",
+        "transportation": "100-200 USD/mes",
+        "medicalInsurance": "100-200 USD/mes",
+        "visaFee": "200-400 USD",
+        "languageCourse": "300-600 USD/mes"
+      },
+      "accommodation": {
+        "sharedAccommodation": "800-1200 USD/mes",
+        "privateAccommodation": "1500-3000 USD/mes",
+        "servicedApartment": "2000-4000 USD/mes",
+        "studentHousing": "600-1000 USD/mes"
+      },
+      "transportation": {
+        "publicTransport": "Sistema MTR, autobuses y tranvías",
+        "taxi": "Disponible y relativamente económico",
+        "ferry": "Transporte a las islas",
+        "airportExpress": "Conexión directa al aeropuerto"
+      },
+      "climate": {
+        "description": "Clima subtropical húmedo con estaciones marcadas",
+        "temperature": "15-30°C promedio anual",
+        "rainfall": "Lluvias abundantes de abril a septiembre",
+        "seasons": "Invierno templado (diciembre-febrero) y verano húmedo (mayo-septiembre)"
+      },
+      "culture": {
+        "language": "Cantonés (oficial), Inglés (oficial), Mandarín",
+        "religion": "Budismo, Taoísmo, Confucianismo",
+        "traditions": "Festivales chinos, tradiciones familiares, feng shui",
+        "festivals": "Año Nuevo Chino, Festival del Dragón, Festival de la Luna"
+      },
+      "education": {
+        "universities": "Universidades de prestigio mundial",
+        "languageSchools": "Cursos de cantonés, mandarín e inglés",
+        "quality": "Educación de clase mundial",
+        "costs": "Costos altos pero calidad excepcional"
+      },
+      "workOpportunities": {
+        "fullTime": "Posiciones en finanzas, tecnología y educación",
+        "sectors": "Finanzas, tecnología, educación, comercio, turismo",
+        "minimumWage": "Salario competitivo internacional",
+        "networking": "Excelentes oportunidades de networking global"
+      },
+      "visaInfo": {
+        "type": "Visa de Trabajo",
+        "duration": "Hasta 2 años (renovable)",
+        "requirements": "Contrato de trabajo, certificados médicos, antecedentes penales",
+        "processingTime": "2-4 semanas"
+      },
+      "costOfLiving": {
+        "monthly": "1500-3000 USD",
+        "accommodation": "800-2000 USD/mes",
+        "food": "400-800 USD/mes",
+        "transport": "100-200 USD/mes",
+        "entertainment": "300-600 USD/mes"
+      },
+      "safety": {
+        "level": "Muy seguro",
+        "crimeRate": "Muy baja",
+        "emergency": "999 (número de emergencia)",
+        "tips": "Ciudad muy segura con leyes estrictas"
+      },
+      "attractions": [
+        "Victoria Peak",
+        "Templo de Wong Tai Sin",
+        "Disneyland Hong Kong",
+        "Ocean Park",
+        "Tsim Sha Tsui",
+        "Lantau Island"
+      ],
+      "events": [
+        "Año Nuevo Chino",
+        "Festival del Dragón",
+        "Festival de la Luna",
+        "Hong Kong Arts Festival",
+        "Hong Kong International Film Festival"
+      ],
+      "testimonials": [
+        {
+          "name": "Ana Chen",
+          "content": "Hong Kong me ofreció oportunidades profesionales increíbles en el sector financiero.",
+          "program": "Work and Study",
+          "rating": 5
+        },
+        {
+          "name": "David Kim",
+          "content": "La fusión cultural de Hong Kong es única. Aprendí tanto sobre negocios como sobre cultura.",
+          "program": "Internship",
+          "rating": 5
+        }
+      ],
+      "faq": [
+        {
+          "question": "¿Necesito visa para trabajar en Hong Kong?",
+          "answer": "Sí, necesitas una visa de trabajo que generalmente gestiona tu empleador. Te ayudamos con todo el proceso."
+        },
+        {
+          "question": "¿Puedo trabajar en Hong Kong sin experiencia previa?",
+          "answer": "Se requiere experiencia profesional y título universitario para la mayoría de posiciones."
+        },
+        {
+          "question": "¿Qué nivel de inglés necesito?",
+          "answer": "Recomendamos nivel avanzado, ya que el inglés es ampliamente usado en el sector profesional."
+        },
+        {
+          "question": "¿Es caro vivir en Hong Kong?",
+          "answer": "Hong Kong es una de las ciudades más caras del mundo, pero los salarios son competitivos."
+        }
+      ],
+      "seoTitle": "Trabaja y Estudia en Hong Kong - Programas Internacionales",
+      "seoDescription": "Descubre las mejores oportunidades de trabajo y estudio en Hong Kong. Centro financiero global con educación de clase mundial.",
+      "seoKeywords": [
+        "Hong Kong",
+        "trabajar en Hong Kong",
+        "estudiar en Hong Kong",
+        "centro financiero",
+        "educación internacional",
+        "visa de trabajo",
+        "Asia",
+        "negocios internacionales"
+      ]
+    }
+  ]
+}

--- a/src/api/hong-kong/services/hong-kong.js
+++ b/src/api/hong-kong/services/hong-kong.js
@@ -1,0 +1,74 @@
+'use strict';
+
+/**
+ * hong-kong service
+ */
+
+const { createCoreService } = require('@strapi/strapi').factories;
+
+module.exports = createCoreService('api::hong-kong.hong-kong', ({ strapi }) => ({
+  // Método personalizado para obtener información completa de Hong Kong
+  async findCompleteInfo() {
+    const hongKong = await strapi.entityService.findMany('api::hong-kong.hong-kong', {
+      filters: { active: true },
+      populate: {
+        image: true,
+        gallery: true
+      }
+    });
+
+    return hongKong;
+  },
+
+  // Método para obtener estadísticas específicas
+  async findStatistics() {
+    const hongKong = await strapi.entityService.findMany('api::hong-kong.hong-kong', {
+      filters: { active: true }
+    });
+
+    return hongKong.map(item => ({
+      id: item.id,
+      statistics: item.statistics,
+      statisticsTitle: item.statisticsTitle
+    }));
+  },
+
+  // Método para obtener tips de viaje específicos
+  async findTravelTips() {
+    const hongKong = await strapi.entityService.findMany('api::hong-kong.hong-kong', {
+      filters: { active: true }
+    });
+
+    return hongKong.map(item => ({
+      id: item.id,
+      travelTips: item.travelTips,
+      travelTipsTitle: item.travelTipsTitle
+    }));
+  },
+
+  // Método para obtener características específicas
+  async findFeatures() {
+    const hongKong = await strapi.entityService.findMany('api::hong-kong.hong-kong', {
+      filters: { active: true }
+    });
+
+    return hongKong.map(item => ({
+      id: item.id,
+      features: item.features,
+      featuresTitle: item.featuresTitle
+    }));
+  },
+
+  // Método para obtener información de programas
+  async findPrograms() {
+    const hongKong = await strapi.entityService.findMany('api::hong-kong.hong-kong', {
+      filters: { active: true }
+    });
+
+    return hongKong.map(item => ({
+      id: item.id,
+      programs: item.programs,
+      requirements: item.requirements
+    }));
+  }
+}));

--- a/src/api/ireland/content-types/ireland/schema.json
+++ b/src/api/ireland/content-types/ireland/schema.json
@@ -1,0 +1,209 @@
+{
+  "kind": "collectionType",
+  "collectionName": "irelands",
+  "info": {
+    "singularName": "ireland",
+    "pluralName": "irelands",
+    "displayName": "Ireland",
+    "description": "Información detallada sobre Irlanda como destino de estudio y trabajo"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "title": {
+      "type": "string",
+      "required": true,
+      "maxLength": 255,
+      "default": "Irlanda"
+    },
+    "slug": {
+      "type": "uid",
+      "targetField": "title",
+      "required": true
+    },
+    "description": {
+      "type": "richtext",
+      "required": true
+    },
+    "shortDescription": {
+      "type": "text",
+      "maxLength": 500
+    },
+    "image": {
+      "type": "media",
+      "multiple": false,
+      "required": true,
+      "allowedTypes": ["images"]
+    },
+    "gallery": {
+      "type": "media",
+      "multiple": true,
+      "allowedTypes": ["images"]
+    },
+    "whyChooseTitle": {
+      "type": "string",
+      "default": "¿Por qué elegir Irlanda?"
+    },
+    "whyChooseItems": {
+      "type": "json"
+    },
+    "hospitalityTitle": {
+      "type": "string",
+      "default": "Hospitalidad Irlandesa"
+    },
+    "hospitalityDescription": {
+      "type": "string",
+      "default": "Experiencia en pubs tradicionales y hoteles boutique"
+    },
+    "hospitalityIcon": {
+      "type": "string",
+      "default": "🍺"
+    },
+    "educationTitle": {
+      "type": "string",
+      "default": "Educación Internacional"
+    },
+    "educationDescription": {
+      "type": "string",
+      "default": "Estudios en instituciones reconocidas mundialmente"
+    },
+    "educationIcon": {
+      "type": "string",
+      "default": "🎓"
+    },
+    "cultureTitle": {
+      "type": "string",
+      "default": "Cultura Única"
+    },
+    "cultureDescription": {
+      "type": "string",
+      "default": "Inmersión en la rica herencia celta y moderna"
+    },
+    "cultureIcon": {
+      "type": "string",
+      "default": "🌍"
+    },
+    "languageTitle": {
+      "type": "string",
+      "default": "Inglés como Idioma"
+    },
+    "languageDescription": {
+      "type": "string",
+      "default": "Mejora tu inglés en un entorno nativo"
+    },
+    "languageIcon": {
+      "type": "string",
+      "default": "💬"
+    },
+    "qualityTitle": {
+      "type": "string",
+      "default": "Calidad de Vida"
+    },
+    "qualityDescription": {
+      "type": "string",
+      "default": "País con alto nivel de vida y seguridad"
+    },
+    "qualityIcon": {
+      "type": "string",
+      "default": "🏠"
+    },
+    "opportunitiesTitle": {
+      "type": "string",
+      "default": "Oportunidades Laborales"
+    },
+    "opportunitiesDescription": {
+      "type": "string",
+      "default": "Acceso al mercado laboral europeo"
+    },
+    "opportunitiesIcon": {
+      "type": "string",
+      "default": "💼"
+    },
+    "statisticsTitle": {
+      "type": "string",
+      "default": "Irlanda en números"
+    },
+    "statistics": {
+      "type": "json"
+    },
+    "featuresTitle": {
+      "type": "string",
+      "default": "Características de Irlanda"
+    },
+    "features": {
+      "type": "json"
+    },
+    "travelTipsTitle": {
+      "type": "string",
+      "default": "Tips de viaje para Irlanda"
+    },
+    "travelTips": {
+      "type": "json"
+    },
+    "programs": {
+      "type": "json"
+    },
+    "requirements": {
+      "type": "json"
+    },
+    "overview": {
+      "type": "json"
+    },
+    "highlights": {
+      "type": "json"
+    },
+    "pricing": {
+      "type": "json"
+    },
+    "accommodation": {
+      "type": "json"
+    },
+    "transportation": {
+      "type": "json"
+    },
+    "climate": {
+      "type": "json"
+    },
+    "culture": {
+      "type": "json"
+    },
+    "education": {
+      "type": "json"
+    },
+    "workOpportunities": {
+      "type": "json"
+    },
+    "visaInfo": {
+      "type": "json"
+    },
+    "costOfLiving": {
+      "type": "json"
+    },
+    "safety": {
+      "type": "json"
+    },
+    "attractions": {
+      "type": "json"
+    },
+    "events": {
+      "type": "json"
+    },
+    "testimonials": {
+      "type": "json"
+    },
+    "faq": {
+      "type": "json"
+    },
+    "seoTitle": {
+      "type": "string"
+    },
+    "seoDescription": {
+      "type": "text"
+    },
+    "seoKeywords": {
+      "type": "json"
+    }
+  }
+}

--- a/src/api/ireland/controllers/ireland.js
+++ b/src/api/ireland/controllers/ireland.js
@@ -1,0 +1,94 @@
+'use strict';
+
+/**
+ * ireland controller
+ */
+
+const { createCoreController } = require('@strapi/strapi').factories;
+
+module.exports = createCoreController('api::ireland.ireland', ({ strapi }) => ({
+  // Método personalizado para obtener información completa de Irlanda
+  async findComplete(ctx) {
+    const entities = await strapi.entityService.findMany('api::ireland.ireland', {
+      filters: { active: true },
+      populate: {
+        image: true,
+        gallery: true
+      }
+    });
+
+    return entities;
+  },
+
+  // Método personalizado para obtener estadísticas de Irlanda
+  async findStats(ctx) {
+    const entities = await strapi.entityService.findMany('api::ireland.ireland', {
+      filters: { active: true },
+      populate: {
+        image: true
+      }
+    });
+
+    // Retornar solo las estadísticas
+    return entities.map(entity => ({
+      id: entity.id,
+      title: entity.title,
+      statistics: entity.statistics,
+      statisticsTitle: entity.statisticsTitle
+    }));
+  },
+
+  // Método personalizado para obtener tips de viaje
+  async findTravelTips(ctx) {
+    const entities = await strapi.entityService.findMany('api::ireland.ireland', {
+      filters: { active: true },
+      populate: {
+        image: true
+      }
+    });
+
+    // Retornar solo los tips de viaje
+    return entities.map(entity => ({
+      id: entity.id,
+      title: entity.title,
+      travelTips: entity.travelTips,
+      travelTipsTitle: entity.travelTipsTitle
+    }));
+  },
+
+  // Método personalizado para obtener características de Irlanda
+  async findFeatures(ctx) {
+    const entities = await strapi.entityService.findMany('api::ireland.ireland', {
+      filters: { active: true },
+      populate: {
+        image: true
+      }
+    });
+
+    // Retornar solo las características
+    return entities.map(entity => ({
+      id: entity.id,
+      title: entity.title,
+      features: entity.features,
+      featuresTitle: entity.featuresTitle
+    }));
+  },
+
+  // Método personalizado para obtener información de programas
+  async findPrograms(ctx) {
+    const entities = await strapi.entityService.findMany('api::ireland.ireland', {
+      filters: { active: true },
+      populate: {
+        image: true
+      }
+    });
+
+    // Retornar solo la información de programas
+    return entities.map(entity => ({
+      id: entity.id,
+      title: entity.title,
+      programs: entity.programs,
+      requirements: entity.requirements
+    }));
+  }
+}));

--- a/src/api/ireland/routes/custom-routes.js
+++ b/src/api/ireland/routes/custom-routes.js
@@ -1,0 +1,50 @@
+'use strict';
+
+/**
+ * Custom routes for ireland
+ */
+
+module.exports = {
+  routes: [
+    {
+      method: 'GET',
+      path: '/irelands/complete',
+      handler: 'ireland.findComplete',
+      config: {
+        auth: false,
+      },
+    },
+    {
+      method: 'GET',
+      path: '/irelands/stats',
+      handler: 'ireland.findStats',
+      config: {
+        auth: false,
+      },
+    },
+    {
+      method: 'GET',
+      path: '/irelands/travel-tips',
+      handler: 'ireland.findTravelTips',
+      config: {
+        auth: false,
+      },
+    },
+    {
+      method: 'GET',
+      path: '/irelands/features',
+      handler: 'ireland.findFeatures',
+      config: {
+        auth: false,
+      },
+    },
+    {
+      method: 'GET',
+      path: '/irelands/programs',
+      handler: 'ireland.findPrograms',
+      config: {
+        auth: false,
+      },
+    },
+  ],
+};

--- a/src/api/ireland/routes/ireland.js
+++ b/src/api/ireland/routes/ireland.js
@@ -1,0 +1,37 @@
+'use strict';
+
+/**
+ * ireland router
+ */
+
+const { createCoreRouter } = require('@strapi/strapi').factories;
+
+module.exports = createCoreRouter('api::ireland.ireland', {
+  config: {
+    find: {
+      auth: false,
+      policies: [],
+      middlewares: [],
+    },
+    findOne: {
+      auth: false,
+      policies: [],
+      middlewares: [],
+    },
+    create: {
+      auth: {
+        strategy: 'jwt',
+      },
+    },
+    update: {
+      auth: {
+        strategy: 'jwt',
+      },
+    },
+    delete: {
+      auth: {
+        strategy: 'jwt',
+      },
+    },
+  },
+});

--- a/src/api/ireland/services/ireland.js
+++ b/src/api/ireland/services/ireland.js
@@ -1,0 +1,74 @@
+'use strict';
+
+/**
+ * ireland service
+ */
+
+const { createCoreService } = require('@strapi/strapi').factories;
+
+module.exports = createCoreService('api::ireland.ireland', ({ strapi }) => ({
+  // Método personalizado para obtener información completa de Irlanda
+  async findCompleteInfo() {
+    const ireland = await strapi.entityService.findMany('api::ireland.ireland', {
+      filters: { active: true },
+      populate: {
+        image: true,
+        gallery: true
+      }
+    });
+
+    return ireland;
+  },
+
+  // Método para obtener estadísticas específicas
+  async findStatistics() {
+    const ireland = await strapi.entityService.findMany('api::ireland.ireland', {
+      filters: { active: true }
+    });
+
+    return ireland.map(item => ({
+      id: item.id,
+      statistics: item.statistics,
+      statisticsTitle: item.statisticsTitle
+    }));
+  },
+
+  // Método para obtener tips de viaje específicos
+  async findTravelTips() {
+    const ireland = await strapi.entityService.findMany('api::ireland.ireland', {
+      filters: { active: true }
+    });
+
+    return ireland.map(item => ({
+      id: item.id,
+      travelTips: item.travelTips,
+      travelTipsTitle: item.travelTipsTitle
+    }));
+  },
+
+  // Método para obtener características específicas
+  async findFeatures() {
+    const ireland = await strapi.entityService.findMany('api::ireland.ireland', {
+      filters: { active: true }
+    });
+
+    return ireland.map(item => ({
+      id: item.id,
+      features: item.features,
+      featuresTitle: item.featuresTitle
+    }));
+  },
+
+  // Método para obtener información de programas
+  async findPrograms() {
+    const ireland = await strapi.entityService.findMany('api::ireland.ireland', {
+      filters: { active: true }
+    });
+
+    return ireland.map(item => ({
+      id: item.id,
+      programs: item.programs,
+      requirements: item.requirements
+    }));
+  }
+}));

--- a/src/api/maldive/content-types/maldive/schema.json
+++ b/src/api/maldive/content-types/maldive/schema.json
@@ -1,0 +1,209 @@
+{
+  "kind": "collectionType",
+  "collectionName": "maldives",
+  "info": {
+    "singularName": "maldive",
+    "pluralName": "maldives",
+    "displayName": "Maldives",
+    "description": "Información detallada sobre Maldivas como destino de estudio y trabajo"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "title": {
+      "type": "string",
+      "required": true,
+      "maxLength": 255,
+      "default": "Maldives"
+    },
+    "slug": {
+      "type": "uid",
+      "targetField": "title",
+      "required": true
+    },
+    "description": {
+      "type": "richtext",
+      "required": true
+    },
+    "shortDescription": {
+      "type": "text",
+      "maxLength": 500
+    },
+    "image": {
+      "type": "media",
+      "multiple": false,
+      "required": true,
+      "allowedTypes": ["images"]
+    },
+    "gallery": {
+      "type": "media",
+      "multiple": true,
+      "allowedTypes": ["images"]
+    },
+    "whyChooseTitle": {
+      "type": "string",
+      "default": "¿Por qué elegir Maldivas?"
+    },
+    "whyChooseItems": {
+      "type": "json"
+    },
+    "hospitalityTitle": {
+      "type": "string",
+      "default": "Turismo de Lujo"
+    },
+    "hospitalityDescription": {
+      "type": "string",
+      "default": "Experiencia en resorts de clase mundial"
+    },
+    "hospitalityIcon": {
+      "type": "string",
+      "default": "🏖️"
+    },
+    "educationTitle": {
+      "type": "string",
+      "default": "Conservación Marina"
+    },
+    "educationDescription": {
+      "type": "string",
+      "default": "Aprendizaje sobre ecosistemas marinos únicos"
+    },
+    "educationIcon": {
+      "type": "string",
+      "default": "🐠"
+    },
+    "cultureTitle": {
+      "type": "string",
+      "default": "Cultura Islámica"
+    },
+    "cultureDescription": {
+      "type": "string",
+      "default": "Inmersión en la cultura islámica del océano Índico"
+    },
+    "cultureIcon": {
+      "type": "string",
+      "default": "🕌"
+    },
+    "languageTitle": {
+      "type": "string",
+      "default": "Idiomas Locales"
+    },
+    "languageDescription": {
+      "type": "string",
+      "default": "Aprende dhivehi e inglés en un paraíso tropical"
+    },
+    "languageIcon": {
+      "type": "string",
+      "default": "🗣️"
+    },
+    "qualityTitle": {
+      "type": "string",
+      "default": "Paraíso Natural"
+    },
+    "qualityDescription": {
+      "type": "string",
+      "default": "Playas vírgenes y arrecifes de coral únicos"
+    },
+    "qualityIcon": {
+      "type": "string",
+      "default": "🌊"
+    },
+    "opportunitiesTitle": {
+      "type": "string",
+      "default": "Hospitalidad Premium"
+    },
+    "opportunitiesDescription": {
+      "type": "string",
+      "default": "Oportunidades en el sector turístico de lujo"
+    },
+    "opportunitiesIcon": {
+      "type": "string",
+      "default": "⭐"
+    },
+    "statisticsTitle": {
+      "type": "string",
+      "default": "Maldivas en números"
+    },
+    "statistics": {
+      "type": "json"
+    },
+    "featuresTitle": {
+      "type": "string",
+      "default": "Características de Maldivas"
+    },
+    "features": {
+      "type": "json"
+    },
+    "travelTipsTitle": {
+      "type": "string",
+      "default": "Tips de viaje para Maldivas"
+    },
+    "travelTips": {
+      "type": "json"
+    },
+    "programs": {
+      "type": "json"
+    },
+    "requirements": {
+      "type": "json"
+    },
+    "overview": {
+      "type": "json"
+    },
+    "highlights": {
+      "type": "json"
+    },
+    "pricing": {
+      "type": "json"
+    },
+    "accommodation": {
+      "type": "json"
+    },
+    "transportation": {
+      "type": "json"
+    },
+    "climate": {
+      "type": "json"
+    },
+    "culture": {
+      "type": "json"
+    },
+    "education": {
+      "type": "json"
+    },
+    "workOpportunities": {
+      "type": "json"
+    },
+    "visaInfo": {
+      "type": "json"
+    },
+    "costOfLiving": {
+      "type": "json"
+    },
+    "safety": {
+      "type": "json"
+    },
+    "attractions": {
+      "type": "json"
+    },
+    "events": {
+      "type": "json"
+    },
+    "testimonials": {
+      "type": "json"
+    },
+    "faq": {
+      "type": "json"
+    },
+    "seoTitle": {
+      "type": "string"
+    },
+    "seoDescription": {
+      "type": "text"
+    },
+    "seoKeywords": {
+      "type": "json"
+    }
+  }
+}

--- a/src/api/maldive/controllers/maldive.js
+++ b/src/api/maldive/controllers/maldive.js
@@ -1,0 +1,94 @@
+'use strict';
+
+/**
+ * maldives controller
+ */
+
+const { createCoreController } = require('@strapi/strapi').factories;
+
+module.exports = createCoreController('api::maldive.maldive', ({ strapi }) => ({
+  // Método personalizado para obtener información completa de Maldivas
+  async findComplete(ctx) {
+    const entities = await strapi.entityService.findMany('api::maldive.maldive', {
+      filters: { active: true },
+      populate: {
+        image: true,
+        gallery: true
+      }
+    });
+
+    return entities;
+  },
+
+  // Método personalizado para obtener estadísticas de Maldivas
+  async findStats(ctx) {
+    const entities = await strapi.entityService.findMany('api::maldive.maldive', {
+      filters: { active: true },
+      populate: {
+        image: true
+      }
+    });
+
+    // Retornar solo las estadísticas
+    return entities.map(entity => ({
+      id: entity.id,
+      title: entity.title,
+      statistics: entity.statistics,
+      statisticsTitle: entity.statisticsTitle
+    }));
+  },
+
+  // Método personalizado para obtener tips de viaje
+  async findTravelTips(ctx) {
+    const entities = await strapi.entityService.findMany('api::maldive.maldive', {
+      filters: { active: true },
+      populate: {
+        image: true
+      }
+    });
+
+    // Retornar solo los tips de viaje
+    return entities.map(entity => ({
+      id: entity.id,
+      title: entity.title,
+      travelTips: entity.travelTips,
+      travelTipsTitle: entity.travelTipsTitle
+    }));
+  },
+
+  // Método personalizado para obtener características de Maldivas
+  async findFeatures(ctx) {
+    const entities = await strapi.entityService.findMany('api::maldive.maldive', {
+      filters: { active: true },
+      populate: {
+        image: true
+      }
+    });
+
+    // Retornar solo las características
+    return entities.map(entity => ({
+      id: entity.id,
+      title: entity.title,
+      features: entity.features,
+      featuresTitle: entity.featuresTitle
+    }));
+  },
+
+  // Método personalizado para obtener información de programas
+  async findPrograms(ctx) {
+    const entities = await strapi.entityService.findMany('api::maldive.maldive', {
+      filters: { active: true },
+      populate: {
+        image: true
+      }
+    });
+
+    // Retornar solo la información de programas
+    return entities.map(entity => ({
+      id: entity.id,
+      title: entity.title,
+      programs: entity.programs,
+      requirements: entity.requirements
+    }));
+  }
+}));

--- a/src/api/maldive/routes/custom-routes.js
+++ b/src/api/maldive/routes/custom-routes.js
@@ -1,0 +1,50 @@
+'use strict';
+
+/**
+ * Custom routes for maldives
+ */
+
+module.exports = {
+  routes: [
+    {
+      method: 'GET',
+      path: '/maldive/complete',
+      handler: 'maldive.findComplete',
+      config: {
+        auth: false,
+      },
+    },
+    {
+      method: 'GET',
+      path: '/maldive/stats',
+      handler: 'maldive.findStats',
+      config: {
+        auth: false,
+      },
+    },
+    {
+      method: 'GET',
+      path: '/maldive/travel-tips',
+      handler: 'maldive.findTravelTips',
+      config: {
+        auth: false,
+      },
+    },
+    {
+      method: 'GET',
+      path: '/maldive/features',
+      handler: 'maldive.findFeatures',
+      config: {
+        auth: false,
+      },
+    },
+    {
+      method: 'GET',
+      path: '/maldive/programs',
+      handler: 'maldive.findPrograms',
+      config: {
+        auth: false,
+      },
+    },
+  ],
+};

--- a/src/api/maldive/routes/maldive.js
+++ b/src/api/maldive/routes/maldive.js
@@ -1,0 +1,37 @@
+'use strict';
+
+/**
+ * maldives router
+ */
+
+const { createCoreRouter } = require('@strapi/strapi').factories;
+
+module.exports = createCoreRouter('api::maldive.maldive', {
+  config: {
+    find: {
+      auth: false,
+      policies: [],
+      middlewares: [],
+    },
+    findOne: {
+      auth: false,
+      policies: [],
+      middlewares: [],
+    },
+    create: {
+      auth: {
+        strategy: 'jwt',
+      },
+    },
+    update: {
+      auth: {
+        strategy: 'jwt',
+      },
+    },
+    delete: {
+      auth: {
+        strategy: 'jwt',
+      },
+    },
+  },
+});

--- a/src/api/maldive/services/maldive.js
+++ b/src/api/maldive/services/maldive.js
@@ -1,0 +1,74 @@
+'use strict';
+
+/**
+ * maldives service
+ */
+
+const { createCoreService } = require('@strapi/strapi').factories;
+
+module.exports = createCoreService('api::maldive.maldive', ({ strapi }) => ({
+  // Método personalizado para obtener información completa de Maldivas
+  async findCompleteInfo() {
+    const maldives = await strapi.entityService.findMany('api::maldive.maldive', {
+      filters: { active: true },
+      populate: {
+        image: true,
+        gallery: true
+      }
+    });
+
+    return maldives;
+  },
+
+  // Método para obtener estadísticas específicas
+  async findStatistics() {
+    const maldives = await strapi.entityService.findMany('api::maldive.maldive', {
+      filters: { active: true }
+    });
+
+    return maldives.map(item => ({
+      id: item.id,
+      statistics: item.statistics,
+      statisticsTitle: item.statisticsTitle
+    }));
+  },
+
+  // Método para obtener tips de viaje específicos
+  async findTravelTips() {
+    const maldives = await strapi.entityService.findMany('api::maldive.maldive', {
+      filters: { active: true }
+    });
+
+    return maldives.map(item => ({
+      id: item.id,
+      travelTips: item.travelTips,
+      travelTipsTitle: item.travelTipsTitle
+    }));
+  },
+
+  // Método para obtener características específicas
+  async findFeatures() {
+    const maldives = await strapi.entityService.findMany('api::maldive.maldive', {
+      filters: { active: true }
+    });
+
+    return maldives.map(item => ({
+      id: item.id,
+      features: item.features,
+      featuresTitle: item.featuresTitle
+    }));
+  },
+
+  // Método para obtener información de programas
+  async findPrograms() {
+    const maldives = await strapi.entityService.findMany('api::maldive.maldive', {
+      filters: { active: true }
+    });
+
+    return maldives.map(item => ({
+      id: item.id,
+      programs: item.programs,
+      requirements: item.requirements
+    }));
+  }
+}));

--- a/src/api/malta/content-types/malta/schema.json
+++ b/src/api/malta/content-types/malta/schema.json
@@ -1,0 +1,209 @@
+{
+  "kind": "collectionType",
+  "collectionName": "maltas",
+  "info": {
+    "singularName": "malta",
+    "pluralName": "maltas",
+    "displayName": "Malta",
+    "description": "Información detallada sobre Malta como destino de estudio y trabajo"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "title": {
+      "type": "string",
+      "required": true,
+      "maxLength": 255,
+      "default": "Malta"
+    },
+    "slug": {
+      "type": "uid",
+      "targetField": "title",
+      "required": true
+    },
+    "description": {
+      "type": "richtext",
+      "required": true
+    },
+    "shortDescription": {
+      "type": "text",
+      "maxLength": 500
+    },
+    "image": {
+      "type": "media",
+      "multiple": false,
+      "required": true,
+      "allowedTypes": ["images"]
+    },
+    "gallery": {
+      "type": "media",
+      "multiple": true,
+      "allowedTypes": ["images"]
+    },
+    "whyChooseTitle": {
+      "type": "string",
+      "default": "¿Por qué elegir Malta?"
+    },
+    "whyChooseItems": {
+      "type": "json"
+    },
+    "hospitalityTitle": {
+      "type": "string",
+      "default": "Historia Mediterránea"
+    },
+    "hospitalityDescription": {
+      "type": "string",
+      "default": "Isla con 7,000 años de historia y cultura"
+    },
+    "hospitalityIcon": {
+      "type": "string",
+      "default": "🏛️"
+    },
+    "educationTitle": {
+      "type": "string",
+      "default": "Educación en Inglés"
+    },
+    "educationDescription": {
+      "type": "string",
+      "default": "Educación de calidad en inglés como idioma oficial"
+    },
+    "educationIcon": {
+      "type": "string",
+      "default": "🎓"
+    },
+    "cultureTitle": {
+      "type": "string",
+      "default": "Cultura Mediterránea"
+    },
+    "cultureDescription": {
+      "type": "string",
+      "default": "Mezcla única de culturas europeas y árabes"
+    },
+    "cultureIcon": {
+      "type": "string",
+      "default": "🌊"
+    },
+    "languageTitle": {
+      "type": "string",
+      "default": "Idiomas Múltiples"
+    },
+    "languageDescription": {
+      "type": "string",
+      "default": "Inglés, maltés e italiano en un solo lugar"
+    },
+    "languageIcon": {
+      "type": "string",
+      "default": "🗣️"
+    },
+    "qualityTitle": {
+      "type": "string",
+      "default": "Calidad de Vida"
+    },
+    "qualityDescription": {
+      "type": "string",
+      "default": "Excelente clima y calidad de vida mediterránea"
+    },
+    "qualityIcon": {
+      "type": "string",
+      "default": "☀️"
+    },
+    "opportunitiesTitle": {
+      "type": "string",
+      "default": "Oportunidades Profesionales"
+    },
+    "opportunitiesDescription": {
+      "type": "string",
+      "default": "Carrera en empresas europeas y sector turístico"
+    },
+    "opportunitiesIcon": {
+      "type": "string",
+      "default": "💼"
+    },
+    "statisticsTitle": {
+      "type": "string",
+      "default": "Malta en números"
+    },
+    "statistics": {
+      "type": "json"
+    },
+    "featuresTitle": {
+      "type": "string",
+      "default": "Características de Malta"
+    },
+    "features": {
+      "type": "json"
+    },
+    "travelTipsTitle": {
+      "type": "string",
+      "default": "Tips de viaje para Malta"
+    },
+    "travelTips": {
+      "type": "json"
+    },
+    "programs": {
+      "type": "json"
+    },
+    "requirements": {
+      "type": "json"
+    },
+    "overview": {
+      "type": "json"
+    },
+    "highlights": {
+      "type": "json"
+    },
+    "pricing": {
+      "type": "json"
+    },
+    "accommodation": {
+      "type": "json"
+    },
+    "transportation": {
+      "type": "json"
+    },
+    "climate": {
+      "type": "json"
+    },
+    "culture": {
+      "type": "json"
+    },
+    "education": {
+      "type": "json"
+    },
+    "workOpportunities": {
+      "type": "json"
+    },
+    "visaInfo": {
+      "type": "json"
+    },
+    "costOfLiving": {
+      "type": "json"
+    },
+    "safety": {
+      "type": "json"
+    },
+    "attractions": {
+      "type": "json"
+    },
+    "events": {
+      "type": "json"
+    },
+    "testimonials": {
+      "type": "json"
+    },
+    "faq": {
+      "type": "json"
+    },
+    "seoTitle": {
+      "type": "string"
+    },
+    "seoDescription": {
+      "type": "text"
+    },
+    "seoKeywords": {
+      "type": "json"
+    }
+  }
+}

--- a/src/api/malta/controllers/malta.js
+++ b/src/api/malta/controllers/malta.js
@@ -1,0 +1,94 @@
+'use strict';
+
+/**
+ * malta controller
+ */
+
+const { createCoreController } = require('@strapi/strapi').factories;
+
+module.exports = createCoreController('api::malta.malta', ({ strapi }) => ({
+  // Método personalizado para obtener información completa de Malta
+  async findComplete(ctx) {
+    const entities = await strapi.entityService.findMany('api::malta.malta', {
+      filters: { active: true },
+      populate: {
+        image: true,
+        gallery: true
+      }
+    });
+
+    return entities;
+  },
+
+  // Método personalizado para obtener estadísticas de Malta
+  async findStats(ctx) {
+    const entities = await strapi.entityService.findMany('api::malta.malta', {
+      filters: { active: true },
+      populate: {
+        image: true
+      }
+    });
+
+    // Retornar solo las estadísticas
+    return entities.map(entity => ({
+      id: entity.id,
+      title: entity.title,
+      statistics: entity.statistics,
+      statisticsTitle: entity.statisticsTitle
+    }));
+  },
+
+  // Método personalizado para obtener tips de viaje
+  async findTravelTips(ctx) {
+    const entities = await strapi.entityService.findMany('api::malta.malta', {
+      filters: { active: true },
+      populate: {
+        image: true
+      }
+    });
+
+    // Retornar solo los tips de viaje
+    return entities.map(entity => ({
+      id: entity.id,
+      title: entity.title,
+      travelTips: entity.travelTips,
+      travelTipsTitle: entity.travelTipsTitle
+    }));
+  },
+
+  // Método personalizado para obtener características de Malta
+  async findFeatures(ctx) {
+    const entities = await strapi.entityService.findMany('api::malta.malta', {
+      filters: { active: true },
+      populate: {
+        image: true
+      }
+    });
+
+    // Retornar solo las características
+    return entities.map(entity => ({
+      id: entity.id,
+      title: entity.title,
+      features: entity.features,
+      featuresTitle: entity.featuresTitle
+    }));
+  },
+
+  // Método personalizado para obtener información de programas
+  async findPrograms(ctx) {
+    const entities = await strapi.entityService.findMany('api::malta.malta', {
+      filters: { active: true },
+      populate: {
+        image: true
+      }
+    });
+
+    // Retornar solo la información de programas
+    return entities.map(entity => ({
+      id: entity.id,
+      title: entity.title,
+      programs: entity.programs,
+      requirements: entity.requirements
+    }));
+  }
+}));

--- a/src/api/malta/routes/custom-routes.js
+++ b/src/api/malta/routes/custom-routes.js
@@ -1,0 +1,50 @@
+'use strict';
+
+/**
+ * Custom routes for malta
+ */
+
+module.exports = {
+  routes: [
+    {
+      method: 'GET',
+      path: '/maltas/complete',
+      handler: 'malta.findComplete',
+      config: {
+        auth: false,
+      },
+    },
+    {
+      method: 'GET',
+      path: '/maltas/stats',
+      handler: 'malta.findStats',
+      config: {
+        auth: false,
+      },
+    },
+    {
+      method: 'GET',
+      path: '/maltas/travel-tips',
+      handler: 'malta.findTravelTips',
+      config: {
+        auth: false,
+      },
+    },
+    {
+      method: 'GET',
+      path: '/maltas/features',
+      handler: 'malta.findFeatures',
+      config: {
+        auth: false,
+      },
+    },
+    {
+      method: 'GET',
+      path: '/maltas/programs',
+      handler: 'malta.findPrograms',
+      config: {
+        auth: false,
+      },
+    },
+  ],
+};

--- a/src/api/malta/routes/malta.js
+++ b/src/api/malta/routes/malta.js
@@ -1,0 +1,37 @@
+'use strict';
+
+/**
+ * malta router
+ */
+
+const { createCoreRouter } = require('@strapi/strapi').factories;
+
+module.exports = createCoreRouter('api::malta.malta', {
+  config: {
+    find: {
+      auth: false,
+      policies: [],
+      middlewares: [],
+    },
+    findOne: {
+      auth: false,
+      policies: [],
+      middlewares: [],
+    },
+    create: {
+      auth: {
+        strategy: 'jwt',
+      },
+    },
+    update: {
+      auth: {
+        strategy: 'jwt',
+      },
+    },
+    delete: {
+      auth: {
+        strategy: 'jwt',
+      },
+    },
+  },
+});

--- a/src/api/malta/services/malta.js
+++ b/src/api/malta/services/malta.js
@@ -1,0 +1,74 @@
+'use strict';
+
+/**
+ * malta service
+ */
+
+const { createCoreService } = require('@strapi/strapi').factories;
+
+module.exports = createCoreService('api::malta.malta', ({ strapi }) => ({
+  // Método personalizado para obtener información completa de Malta
+  async findCompleteInfo() {
+    const malta = await strapi.entityService.findMany('api::malta.malta', {
+      filters: { active: true },
+      populate: {
+        image: true,
+        gallery: true
+      }
+    });
+
+    return malta;
+  },
+
+  // Método para obtener estadísticas específicas
+  async findStatistics() {
+    const malta = await strapi.entityService.findMany('api::malta.malta', {
+      filters: { active: true }
+    });
+
+    return malta.map(item => ({
+      id: item.id,
+      statistics: item.statistics,
+      statisticsTitle: item.statisticsTitle
+    }));
+  },
+
+  // Método para obtener tips de viaje específicos
+  async findTravelTips() {
+    const malta = await strapi.entityService.findMany('api::malta.malta', {
+      filters: { active: true }
+    });
+
+    return malta.map(item => ({
+      id: item.id,
+      travelTips: item.travelTips,
+      travelTipsTitle: item.travelTipsTitle
+    }));
+  },
+
+  // Método para obtener características específicas
+  async findFeatures() {
+    const malta = await strapi.entityService.findMany('api::malta.malta', {
+      filters: { active: true }
+    });
+
+    return malta.map(item => ({
+      id: item.id,
+      features: item.features,
+      featuresTitle: item.featuresTitle
+    }));
+  },
+
+  // Método para obtener información de programas
+  async findPrograms() {
+    const malta = await strapi.entityService.findMany('api::malta.malta', {
+      filters: { active: true }
+    });
+
+    return malta.map(item => ({
+      id: item.id,
+      programs: item.programs,
+      requirements: item.requirements
+    }));
+  }
+}));

--- a/src/api/prague/content-types/prague/schema.json
+++ b/src/api/prague/content-types/prague/schema.json
@@ -1,0 +1,209 @@
+{
+  "kind": "collectionType",
+  "collectionName": "pragues",
+  "info": {
+    "singularName": "prague",
+    "pluralName": "pragues",
+    "displayName": "Prague",
+    "description": "Información detallada sobre Praga como destino de estudio y trabajo"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "title": {
+      "type": "string",
+      "required": true,
+      "maxLength": 255,
+      "default": "Prague"
+    },
+    "slug": {
+      "type": "uid",
+      "targetField": "title",
+      "required": true
+    },
+    "description": {
+      "type": "richtext",
+      "required": true
+    },
+    "shortDescription": {
+      "type": "text",
+      "maxLength": 500
+    },
+    "image": {
+      "type": "media",
+      "multiple": false,
+      "required": true,
+      "allowedTypes": ["images"]
+    },
+    "gallery": {
+      "type": "media",
+      "multiple": true,
+      "allowedTypes": ["images"]
+    },
+    "whyChooseTitle": {
+      "type": "string",
+      "default": "¿Por qué elegir Praga?"
+    },
+    "whyChooseItems": {
+      "type": "json"
+    },
+    "hospitalityTitle": {
+      "type": "string",
+      "default": "Historia Milenaria"
+    },
+    "hospitalityDescription": {
+      "type": "string",
+      "default": "Ciudad medieval perfectamente conservada"
+    },
+    "hospitalityIcon": {
+      "type": "string",
+      "default": "🏰"
+    },
+    "educationTitle": {
+      "type": "string",
+      "default": "Educación de Calidad"
+    },
+    "educationDescription": {
+      "type": "string",
+      "default": "Universidades de prestigio con costos accesibles"
+    },
+    "educationIcon": {
+      "type": "string",
+      "default": "🎓"
+    },
+    "cultureTitle": {
+      "type": "string",
+      "default": "Cultura Bohemia"
+    },
+    "cultureDescription": {
+      "type": "string",
+      "default": "Arte, música y literatura de clase mundial"
+    },
+    "cultureIcon": {
+      "type": "string",
+      "default": "🎭"
+    },
+    "languageTitle": {
+      "type": "string",
+      "default": "Idiomas Europeos"
+    },
+    "languageDescription": {
+      "type": "string",
+      "default": "Aprende checo, inglés y otros idiomas europeos"
+    },
+    "languageIcon": {
+      "type": "string",
+      "default": "🗣️"
+    },
+    "qualityTitle": {
+      "type": "string",
+      "default": "Calidad de Vida"
+    },
+    "qualityDescription": {
+      "type": "string",
+      "default": "Excelente relación calidad-precio en Europa"
+    },
+    "qualityIcon": {
+      "type": "string",
+      "default": "🏠"
+    },
+    "opportunitiesTitle": {
+      "type": "string",
+      "default": "Oportunidades Profesionales"
+    },
+    "opportunitiesDescription": {
+      "type": "string",
+      "default": "Carrera en empresas europeas y startups"
+    },
+    "opportunitiesIcon": {
+      "type": "string",
+      "default": "💼"
+    },
+    "statisticsTitle": {
+      "type": "string",
+      "default": "Praga en números"
+    },
+    "statistics": {
+      "type": "json"
+    },
+    "featuresTitle": {
+      "type": "string",
+      "default": "Características de Praga"
+    },
+    "features": {
+      "type": "json"
+    },
+    "travelTipsTitle": {
+      "type": "string",
+      "default": "Tips de viaje para Praga"
+    },
+    "travelTips": {
+      "type": "json"
+    },
+    "programs": {
+      "type": "json"
+    },
+    "requirements": {
+      "type": "json"
+    },
+    "overview": {
+      "type": "json"
+    },
+    "highlights": {
+      "type": "json"
+    },
+    "pricing": {
+      "type": "json"
+    },
+    "accommodation": {
+      "type": "json"
+    },
+    "transportation": {
+      "type": "json"
+    },
+    "climate": {
+      "type": "json"
+    },
+    "culture": {
+      "type": "json"
+    },
+    "education": {
+      "type": "json"
+    },
+    "workOpportunities": {
+      "type": "json"
+    },
+    "visaInfo": {
+      "type": "json"
+    },
+    "costOfLiving": {
+      "type": "json"
+    },
+    "safety": {
+      "type": "json"
+    },
+    "attractions": {
+      "type": "json"
+    },
+    "events": {
+      "type": "json"
+    },
+    "testimonials": {
+      "type": "json"
+    },
+    "faq": {
+      "type": "json"
+    },
+    "seoTitle": {
+      "type": "string"
+    },
+    "seoDescription": {
+      "type": "text"
+    },
+    "seoKeywords": {
+      "type": "json"
+    }
+  }
+}

--- a/src/api/prague/controllers/prague.js
+++ b/src/api/prague/controllers/prague.js
@@ -1,0 +1,94 @@
+'use strict';
+
+/**
+ * prague controller
+ */
+
+const { createCoreController } = require('@strapi/strapi').factories;
+
+module.exports = createCoreController('api::prague.prague', ({ strapi }) => ({
+  // Método personalizado para obtener información completa de Praga
+  async findComplete(ctx) {
+    const entities = await strapi.entityService.findMany('api::prague.prague', {
+      filters: { active: true },
+      populate: {
+        image: true,
+        gallery: true
+      }
+    });
+
+    return entities;
+  },
+
+  // Método personalizado para obtener estadísticas de Praga
+  async findStats(ctx) {
+    const entities = await strapi.entityService.findMany('api::prague.prague', {
+      filters: { active: true },
+      populate: {
+        image: true
+      }
+    });
+
+    // Retornar solo las estadísticas
+    return entities.map(entity => ({
+      id: entity.id,
+      title: entity.title,
+      statistics: entity.statistics,
+      statisticsTitle: entity.statisticsTitle
+    }));
+  },
+
+  // Método personalizado para obtener tips de viaje
+  async findTravelTips(ctx) {
+    const entities = await strapi.entityService.findMany('api::prague.prague', {
+      filters: { active: true },
+      populate: {
+        image: true
+      }
+    });
+
+    // Retornar solo los tips de viaje
+    return entities.map(entity => ({
+      id: entity.id,
+      title: entity.title,
+      travelTips: entity.travelTips,
+      travelTipsTitle: entity.travelTipsTitle
+    }));
+  },
+
+  // Método personalizado para obtener características de Praga
+  async findFeatures(ctx) {
+    const entities = await strapi.entityService.findMany('api::prague.prague', {
+      filters: { active: true },
+      populate: {
+        image: true
+      }
+    });
+
+    // Retornar solo las características
+    return entities.map(entity => ({
+      id: entity.id,
+      title: entity.title,
+      features: entity.features,
+      featuresTitle: entity.featuresTitle
+    }));
+  },
+
+  // Método personalizado para obtener información de programas
+  async findPrograms(ctx) {
+    const entities = await strapi.entityService.findMany('api::prague.prague', {
+      filters: { active: true },
+      populate: {
+        image: true
+      }
+    });
+
+    // Retornar solo la información de programas
+    return entities.map(entity => ({
+      id: entity.id,
+      title: entity.title,
+      programs: entity.programs,
+      requirements: entity.requirements
+    }));
+  }
+}));

--- a/src/api/prague/routes/custom-routes.js
+++ b/src/api/prague/routes/custom-routes.js
@@ -1,0 +1,50 @@
+'use strict';
+
+/**
+ * Custom routes for prague
+ */
+
+module.exports = {
+  routes: [
+    {
+      method: 'GET',
+      path: '/pragues/complete',
+      handler: 'prague.findComplete',
+      config: {
+        auth: false,
+      },
+    },
+    {
+      method: 'GET',
+      path: '/pragues/stats',
+      handler: 'prague.findStats',
+      config: {
+        auth: false,
+      },
+    },
+    {
+      method: 'GET',
+      path: '/pragues/travel-tips',
+      handler: 'prague.findTravelTips',
+      config: {
+        auth: false,
+      },
+    },
+    {
+      method: 'GET',
+      path: '/pragues/features',
+      handler: 'prague.findFeatures',
+      config: {
+        auth: false,
+      },
+    },
+    {
+      method: 'GET',
+      path: '/pragues/programs',
+      handler: 'prague.findPrograms',
+      config: {
+        auth: false,
+      },
+    },
+  ],
+};

--- a/src/api/prague/routes/prague.js
+++ b/src/api/prague/routes/prague.js
@@ -1,0 +1,37 @@
+'use strict';
+
+/**
+ * prague router
+ */
+
+const { createCoreRouter } = require('@strapi/strapi').factories;
+
+module.exports = createCoreRouter('api::prague.prague', {
+  config: {
+    find: {
+      auth: false,
+      policies: [],
+      middlewares: [],
+    },
+    findOne: {
+      auth: false,
+      policies: [],
+      middlewares: [],
+    },
+    create: {
+      auth: {
+        strategy: 'jwt',
+      },
+    },
+    update: {
+      auth: {
+        strategy: 'jwt',
+      },
+    },
+    delete: {
+      auth: {
+        strategy: 'jwt',
+      },
+    },
+  },
+});

--- a/src/api/prague/services/prague.js
+++ b/src/api/prague/services/prague.js
@@ -1,0 +1,74 @@
+'use strict';
+
+/**
+ * prague service
+ */
+
+const { createCoreService } = require('@strapi/strapi').factories;
+
+module.exports = createCoreService('api::prague.prague', ({ strapi }) => ({
+  // Método personalizado para obtener información completa de Praga
+  async findCompleteInfo() {
+    const prague = await strapi.entityService.findMany('api::prague.prague', {
+      filters: { active: true },
+      populate: {
+        image: true,
+        gallery: true
+      }
+    });
+
+    return prague;
+  },
+
+  // Método para obtener estadísticas específicas
+  async findStatistics() {
+    const prague = await strapi.entityService.findMany('api::prague.prague', {
+      filters: { active: true }
+    });
+
+    return prague.map(item => ({
+      id: item.id,
+      statistics: item.statistics,
+      statisticsTitle: item.statisticsTitle
+    }));
+  },
+
+  // Método para obtener tips de viaje específicos
+  async findTravelTips() {
+    const prague = await strapi.entityService.findMany('api::prague.prague', {
+      filters: { active: true }
+    });
+
+    return prague.map(item => ({
+      id: item.id,
+      travelTips: item.travelTips,
+      travelTipsTitle: item.travelTipsTitle
+    }));
+  },
+
+  // Método para obtener características específicas
+  async findFeatures() {
+    const prague = await strapi.entityService.findMany('api::prague.prague', {
+      filters: { active: true }
+    });
+
+    return prague.map(item => ({
+      id: item.id,
+      features: item.features,
+      featuresTitle: item.featuresTitle
+    }));
+  },
+
+  // Método para obtener información de programas
+  async findPrograms() {
+    const prague = await strapi.entityService.findMany('api::prague.prague', {
+      filters: { active: true }
+    });
+
+    return prague.map(item => ({
+      id: item.id,
+      programs: item.programs,
+      requirements: item.requirements
+    }));
+  }
+}));

--- a/src/api/qatar/content-types/qatar/schema.json
+++ b/src/api/qatar/content-types/qatar/schema.json
@@ -1,0 +1,209 @@
+{
+  "kind": "collectionType",
+  "collectionName": "qatars",
+  "info": {
+    "singularName": "qatar",
+    "pluralName": "qatars",
+    "displayName": "Qatar",
+    "description": "Información detallada sobre Qatar como destino de estudio y trabajo"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "title": {
+      "type": "string",
+      "required": true,
+      "maxLength": 255,
+      "default": "Qatar"
+    },
+    "slug": {
+      "type": "uid",
+      "targetField": "title",
+      "required": true
+    },
+    "description": {
+      "type": "richtext",
+      "required": true
+    },
+    "shortDescription": {
+      "type": "text",
+      "maxLength": 500
+    },
+    "image": {
+      "type": "media",
+      "multiple": false,
+      "required": true,
+      "allowedTypes": ["images"]
+    },
+    "gallery": {
+      "type": "media",
+      "multiple": true,
+      "allowedTypes": ["images"]
+    },
+    "whyChooseTitle": {
+      "type": "string",
+      "default": "¿Por qué elegir Qatar?"
+    },
+    "whyChooseItems": {
+      "type": "json"
+    },
+    "hospitalityTitle": {
+      "type": "string",
+      "default": "Hospitalidad de Lujo"
+    },
+    "hospitalityDescription": {
+      "type": "string",
+      "default": "Experiencia en los hoteles más prestigiosos del Medio Oriente"
+    },
+    "hospitalityIcon": {
+      "type": "string",
+      "default": "⭐"
+    },
+    "educationTitle": {
+      "type": "string",
+      "default": "Eventos Internacionales"
+    },
+    "educationDescription": {
+      "type": "string",
+      "default": "Participación en la organización de eventos deportivos y culturales"
+    },
+    "educationIcon": {
+      "type": "string",
+      "default": "🏆"
+    },
+    "cultureTitle": {
+      "type": "string",
+      "default": "Desarrollo Profesional"
+    },
+    "cultureDescription": {
+      "type": "string",
+      "default": "Formación en estándares internacionales de servicio"
+    },
+    "cultureIcon": {
+      "type": "string",
+      "default": "📈"
+    },
+    "languageTitle": {
+      "type": "string",
+      "default": "Paquete Completo"
+    },
+    "languageDescription": {
+      "type": "string",
+      "default": "Alojamiento y transporte incluidos en la mayoría de posiciones"
+    },
+    "languageIcon": {
+      "type": "string",
+      "default": "📦"
+    },
+    "qualityTitle": {
+      "type": "string",
+      "default": "Ambiente Multicultural"
+    },
+    "qualityDescription": {
+      "type": "string",
+      "default": "Trabajo con profesionales de todo el mundo"
+    },
+    "qualityIcon": {
+      "type": "string",
+      "default": "🌍"
+    },
+    "opportunitiesTitle": {
+      "type": "string",
+      "default": "Beneficios Atractivos"
+    },
+    "opportunitiesDescription": {
+      "type": "string",
+      "default": "Salario libre de impuestos y bonificaciones"
+    },
+    "opportunitiesIcon": {
+      "type": "string",
+      "default": "💰"
+    },
+    "statisticsTitle": {
+      "type": "string",
+      "default": "Qatar en números"
+    },
+    "statistics": {
+      "type": "json"
+    },
+    "featuresTitle": {
+      "type": "string",
+      "default": "Características de Qatar"
+    },
+    "features": {
+      "type": "json"
+    },
+    "travelTipsTitle": {
+      "type": "string",
+      "default": "Tips de viaje para Qatar"
+    },
+    "travelTips": {
+      "type": "json"
+    },
+    "programs": {
+      "type": "json"
+    },
+    "requirements": {
+      "type": "json"
+    },
+    "overview": {
+      "type": "json"
+    },
+    "highlights": {
+      "type": "json"
+    },
+    "pricing": {
+      "type": "json"
+    },
+    "accommodation": {
+      "type": "json"
+    },
+    "transportation": {
+      "type": "json"
+    },
+    "climate": {
+      "type": "json"
+    },
+    "culture": {
+      "type": "json"
+    },
+    "education": {
+      "type": "json"
+    },
+    "workOpportunities": {
+      "type": "json"
+    },
+    "visaInfo": {
+      "type": "json"
+    },
+    "costOfLiving": {
+      "type": "json"
+    },
+    "safety": {
+      "type": "json"
+    },
+    "attractions": {
+      "type": "json"
+    },
+    "events": {
+      "type": "json"
+    },
+    "testimonials": {
+      "type": "json"
+    },
+    "faq": {
+      "type": "json"
+    },
+    "seoTitle": {
+      "type": "string"
+    },
+    "seoDescription": {
+      "type": "text"
+    },
+    "seoKeywords": {
+      "type": "json"
+    }
+  }
+}

--- a/src/api/qatar/controllers/qatar.js
+++ b/src/api/qatar/controllers/qatar.js
@@ -1,0 +1,94 @@
+'use strict';
+
+/**
+ * qatar controller
+ */
+
+const { createCoreController } = require('@strapi/strapi').factories;
+
+module.exports = createCoreController('api::qatar.qatar', ({ strapi }) => ({
+  // Método personalizado para obtener información completa de Qatar
+  async findComplete(ctx) {
+    const entities = await strapi.entityService.findMany('api::qatar.qatar', {
+      filters: { active: true },
+      populate: {
+        image: true,
+        gallery: true
+      }
+    });
+
+    return entities;
+  },
+
+  // Método personalizado para obtener estadísticas de Qatar
+  async findStats(ctx) {
+    const entities = await strapi.entityService.findMany('api::qatar.qatar', {
+      filters: { active: true },
+      populate: {
+        image: true
+      }
+    });
+
+    // Retornar solo las estadísticas
+    return entities.map(entity => ({
+      id: entity.id,
+      title: entity.title,
+      statistics: entity.statistics,
+      statisticsTitle: entity.statisticsTitle
+    }));
+  },
+
+  // Método personalizado para obtener tips de viaje
+  async findTravelTips(ctx) {
+    const entities = await strapi.entityService.findMany('api::qatar.qatar', {
+      filters: { active: true },
+      populate: {
+        image: true
+      }
+    });
+
+    // Retornar solo los tips de viaje
+    return entities.map(entity => ({
+      id: entity.id,
+      title: entity.title,
+      travelTips: entity.travelTips,
+      travelTipsTitle: entity.travelTipsTitle
+    }));
+  },
+
+  // Método personalizado para obtener características de Qatar
+  async findFeatures(ctx) {
+    const entities = await strapi.entityService.findMany('api::qatar.qatar', {
+      filters: { active: true },
+      populate: {
+        image: true
+      }
+    });
+
+    // Retornar solo las características
+    return entities.map(entity => ({
+      id: entity.id,
+      title: entity.title,
+      features: entity.features,
+      featuresTitle: entity.featuresTitle
+    }));
+  },
+
+  // Método personalizado para obtener información de programas
+  async findPrograms(ctx) {
+    const entities = await strapi.entityService.findMany('api::qatar.qatar', {
+      filters: { active: true },
+      populate: {
+        image: true
+      }
+    });
+
+    // Retornar solo la información de programas
+    return entities.map(entity => ({
+      id: entity.id,
+      title: entity.title,
+      programs: entity.programs,
+      requirements: entity.requirements
+    }));
+  }
+}));

--- a/src/api/qatar/routes/custom-routes.js
+++ b/src/api/qatar/routes/custom-routes.js
@@ -1,0 +1,50 @@
+'use strict';
+
+/**
+ * Custom routes for qatar
+ */
+
+module.exports = {
+  routes: [
+    {
+      method: 'GET',
+      path: '/qatars/complete',
+      handler: 'qatar.findComplete',
+      config: {
+        auth: false,
+      },
+    },
+    {
+      method: 'GET',
+      path: '/qatars/stats',
+      handler: 'qatar.findStats',
+      config: {
+        auth: false,
+      },
+    },
+    {
+      method: 'GET',
+      path: '/qatars/travel-tips',
+      handler: 'qatar.findTravelTips',
+      config: {
+        auth: false,
+      },
+    },
+    {
+      method: 'GET',
+      path: '/qatars/features',
+      handler: 'qatar.findFeatures',
+      config: {
+        auth: false,
+      },
+    },
+    {
+      method: 'GET',
+      path: '/qatars/programs',
+      handler: 'qatar.findPrograms',
+      config: {
+        auth: false,
+      },
+    },
+  ],
+};

--- a/src/api/qatar/routes/qatar.js
+++ b/src/api/qatar/routes/qatar.js
@@ -1,0 +1,37 @@
+'use strict';
+
+/**
+ * qatar router
+ */
+
+const { createCoreRouter } = require('@strapi/strapi').factories;
+
+module.exports = createCoreRouter('api::qatar.qatar', {
+  config: {
+    find: {
+      auth: false,
+      policies: [],
+      middlewares: [],
+    },
+    findOne: {
+      auth: false,
+      policies: [],
+      middlewares: [],
+    },
+    create: {
+      auth: {
+        strategy: 'jwt',
+      },
+    },
+    update: {
+      auth: {
+        strategy: 'jwt',
+      },
+    },
+    delete: {
+      auth: {
+        strategy: 'jwt',
+      },
+    },
+  },
+});

--- a/src/api/qatar/services/qatar.js
+++ b/src/api/qatar/services/qatar.js
@@ -1,0 +1,74 @@
+'use strict';
+
+/**
+ * qatar service
+ */
+
+const { createCoreService } = require('@strapi/strapi').factories;
+
+module.exports = createCoreService('api::qatar.qatar', ({ strapi }) => ({
+  // Método personalizado para obtener información completa de Qatar
+  async findCompleteInfo() {
+    const qatar = await strapi.entityService.findMany('api::qatar.qatar', {
+      filters: { active: true },
+      populate: {
+        image: true,
+        gallery: true
+      }
+    });
+
+    return qatar;
+  },
+
+  // Método para obtener estadísticas específicas
+  async findStatistics() {
+    const qatar = await strapi.entityService.findMany('api::qatar.qatar', {
+      filters: { active: true }
+    });
+
+    return qatar.map(item => ({
+      id: item.id,
+      statistics: item.statistics,
+      statisticsTitle: item.statisticsTitle
+    }));
+  },
+
+  // Método para obtener tips de viaje específicos
+  async findTravelTips() {
+    const qatar = await strapi.entityService.findMany('api::qatar.qatar', {
+      filters: { active: true }
+    });
+
+    return qatar.map(item => ({
+      id: item.id,
+      travelTips: item.travelTips,
+      travelTipsTitle: item.travelTipsTitle
+    }));
+  },
+
+  // Método para obtener características específicas
+  async findFeatures() {
+    const qatar = await strapi.entityService.findMany('api::qatar.qatar', {
+      filters: { active: true }
+    });
+
+    return qatar.map(item => ({
+      id: item.id,
+      features: item.features,
+      featuresTitle: item.featuresTitle
+    }));
+  },
+
+  // Método para obtener información de programas
+  async findPrograms() {
+    const qatar = await strapi.entityService.findMany('api::qatar.qatar', {
+      filters: { active: true }
+    });
+
+    return qatar.map(item => ({
+      id: item.id,
+      programs: item.programs,
+      requirements: item.requirements
+    }));
+  }
+}));

--- a/src/api/spain/content-types/spain/schema.json
+++ b/src/api/spain/content-types/spain/schema.json
@@ -1,0 +1,209 @@
+{
+  "kind": "collectionType",
+  "collectionName": "spains",
+  "info": {
+    "singularName": "spain",
+    "pluralName": "spains",
+    "displayName": "Spain",
+    "description": "Información detallada sobre España como destino de estudio y trabajo"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "title": {
+      "type": "string",
+      "required": true,
+      "maxLength": 255,
+      "default": "Spain"
+    },
+    "slug": {
+      "type": "uid",
+      "targetField": "title",
+      "required": true
+    },
+    "description": {
+      "type": "richtext",
+      "required": true
+    },
+    "shortDescription": {
+      "type": "text",
+      "maxLength": 500
+    },
+    "image": {
+      "type": "media",
+      "multiple": false,
+      "required": true,
+      "allowedTypes": ["images"]
+    },
+    "gallery": {
+      "type": "media",
+      "multiple": true,
+      "allowedTypes": ["images"]
+    },
+    "whyChooseTitle": {
+      "type": "string",
+      "default": "¿Por qué elegir España?"
+    },
+    "whyChooseItems": {
+      "type": "json"
+    },
+    "hospitalityTitle": {
+      "type": "string",
+      "default": "Cultura Rica"
+    },
+    "hospitalityDescription": {
+      "type": "string",
+      "default": "País con rica historia y tradiciones culturales"
+    },
+    "hospitalityIcon": {
+      "type": "string",
+      "default": "🎭"
+    },
+    "educationTitle": {
+      "type": "string",
+      "default": "Educación de Calidad"
+    },
+    "educationDescription": {
+      "type": "string",
+      "default": "Universidades de prestigio con costos accesibles"
+    },
+    "educationIcon": {
+      "type": "string",
+      "default": "🎓"
+    },
+    "cultureTitle": {
+      "type": "string",
+      "default": "Idioma Español"
+    },
+    "cultureDescription": {
+      "type": "string",
+      "default": "Español como idioma oficial en su cuna"
+    },
+    "cultureIcon": {
+      "type": "string",
+      "default": "🗣️"
+    },
+    "languageTitle": {
+      "type": "string",
+      "default": "Clima Mediterráneo"
+    },
+    "languageDescription": {
+      "type": "string",
+      "default": "Excelente clima y calidad de vida mediterránea"
+    },
+    "languageIcon": {
+      "type": "string",
+      "default": "☀️"
+    },
+    "qualityTitle": {
+      "type": "string",
+      "default": "Calidad de Vida"
+    },
+    "qualityDescription": {
+      "type": "string",
+      "default": "Excelente calidad de vida y servicios públicos"
+    },
+    "qualityIcon": {
+      "type": "string",
+      "default": "🏠"
+    },
+    "opportunitiesTitle": {
+      "type": "string",
+      "default": "Oportunidades Profesionales"
+    },
+    "opportunitiesDescription": {
+      "type": "string",
+      "default": "Carrera en empresas europeas y startups"
+    },
+    "opportunitiesIcon": {
+      "type": "string",
+      "default": "💼"
+    },
+    "statisticsTitle": {
+      "type": "string",
+      "default": "España en números"
+    },
+    "statistics": {
+      "type": "json"
+    },
+    "featuresTitle": {
+      "type": "string",
+      "default": "Características de España"
+    },
+    "features": {
+      "type": "json"
+    },
+    "travelTipsTitle": {
+      "type": "string",
+      "default": "Tips de viaje para España"
+    },
+    "travelTips": {
+      "type": "json"
+    },
+    "programs": {
+      "type": "json"
+    },
+    "requirements": {
+      "type": "json"
+    },
+    "overview": {
+      "type": "json"
+    },
+    "highlights": {
+      "type": "json"
+    },
+    "pricing": {
+      "type": "json"
+    },
+    "accommodation": {
+      "type": "json"
+    },
+    "transportation": {
+      "type": "json"
+    },
+    "climate": {
+      "type": "json"
+    },
+    "culture": {
+      "type": "json"
+    },
+    "education": {
+      "type": "json"
+    },
+    "workOpportunities": {
+      "type": "json"
+    },
+    "visaInfo": {
+      "type": "json"
+    },
+    "costOfLiving": {
+      "type": "json"
+    },
+    "safety": {
+      "type": "json"
+    },
+    "attractions": {
+      "type": "json"
+    },
+    "events": {
+      "type": "json"
+    },
+    "testimonials": {
+      "type": "json"
+    },
+    "faq": {
+      "type": "json"
+    },
+    "seoTitle": {
+      "type": "string"
+    },
+    "seoDescription": {
+      "type": "text"
+    },
+    "seoKeywords": {
+      "type": "json"
+    }
+  }
+}

--- a/src/api/spain/controllers/spain.js
+++ b/src/api/spain/controllers/spain.js
@@ -1,0 +1,94 @@
+'use strict';
+
+/**
+ * spain controller
+ */
+
+const { createCoreController } = require('@strapi/strapi').factories;
+
+module.exports = createCoreController('api::spain.spain', ({ strapi }) => ({
+  // Método personalizado para obtener información completa de España
+  async findComplete(ctx) {
+    const entities = await strapi.entityService.findMany('api::spain.spain', {
+      filters: { active: true },
+      populate: {
+        image: true,
+        gallery: true
+      }
+    });
+
+    return entities;
+  },
+
+  // Método personalizado para obtener estadísticas de España
+  async findStats(ctx) {
+    const entities = await strapi.entityService.findMany('api::spain.spain', {
+      filters: { active: true },
+      populate: {
+        image: true
+      }
+    });
+
+    // Retornar solo las estadísticas
+    return entities.map(entity => ({
+      id: entity.id,
+      title: entity.title,
+      statistics: entity.statistics,
+      statisticsTitle: entity.statisticsTitle
+    }));
+  },
+
+  // Método personalizado para obtener tips de viaje
+  async findTravelTips(ctx) {
+    const entities = await strapi.entityService.findMany('api::spain.spain', {
+      filters: { active: true },
+      populate: {
+        image: true
+      }
+    });
+
+    // Retornar solo los tips de viaje
+    return entities.map(entity => ({
+      id: entity.id,
+      title: entity.title,
+      travelTips: entity.travelTips,
+      travelTipsTitle: entity.travelTipsTitle
+    }));
+  },
+
+  // Método personalizado para obtener características de España
+  async findFeatures(ctx) {
+    const entities = await strapi.entityService.findMany('api::spain.spain', {
+      filters: { active: true },
+      populate: {
+        image: true
+      }
+    });
+
+    // Retornar solo las características
+    return entities.map(entity => ({
+      id: entity.id,
+      title: entity.title,
+      features: entity.features,
+      featuresTitle: entity.featuresTitle
+    }));
+  },
+
+  // Método personalizado para obtener información de programas
+  async findPrograms(ctx) {
+    const entities = await strapi.entityService.findMany('api::spain.spain', {
+      filters: { active: true },
+      populate: {
+        image: true
+      }
+    });
+
+    // Retornar solo la información de programas
+    return entities.map(entity => ({
+      id: entity.id,
+      title: entity.title,
+      programs: entity.programs,
+      requirements: entity.requirements
+    }));
+  }
+}));

--- a/src/api/spain/routes/custom-routes.js
+++ b/src/api/spain/routes/custom-routes.js
@@ -1,0 +1,50 @@
+'use strict';
+
+/**
+ * Custom routes for spain
+ */
+
+module.exports = {
+  routes: [
+    {
+      method: 'GET',
+      path: '/spains/complete',
+      handler: 'spain.findComplete',
+      config: {
+        auth: false,
+      },
+    },
+    {
+      method: 'GET',
+      path: '/spains/stats',
+      handler: 'spain.findStats',
+      config: {
+        auth: false,
+      },
+    },
+    {
+      method: 'GET',
+      path: '/spains/travel-tips',
+      handler: 'spain.findTravelTips',
+      config: {
+        auth: false,
+      },
+    },
+    {
+      method: 'GET',
+      path: '/spains/features',
+      handler: 'spain.findFeatures',
+      config: {
+        auth: false,
+      },
+    },
+    {
+      method: 'GET',
+      path: '/spains/programs',
+      handler: 'spain.findPrograms',
+      config: {
+        auth: false,
+      },
+    },
+  ],
+};

--- a/src/api/spain/routes/spain.js
+++ b/src/api/spain/routes/spain.js
@@ -1,0 +1,37 @@
+'use strict';
+
+/**
+ * spain router
+ */
+
+const { createCoreRouter } = require('@strapi/strapi').factories;
+
+module.exports = createCoreRouter('api::spain.spain', {
+  config: {
+    find: {
+      auth: false,
+      policies: [],
+      middlewares: [],
+    },
+    findOne: {
+      auth: false,
+      policies: [],
+      middlewares: [],
+    },
+    create: {
+      auth: {
+        strategy: 'jwt',
+      },
+    },
+    update: {
+      auth: {
+        strategy: 'jwt',
+      },
+    },
+    delete: {
+      auth: {
+        strategy: 'jwt',
+      },
+    },
+  },
+});

--- a/src/api/spain/services/spain.js
+++ b/src/api/spain/services/spain.js
@@ -1,0 +1,74 @@
+'use strict';
+
+/**
+ * spain service
+ */
+
+const { createCoreService } = require('@strapi/strapi').factories;
+
+module.exports = createCoreService('api::spain.spain', ({ strapi }) => ({
+  // Método personalizado para obtener información completa de España
+  async findCompleteInfo() {
+    const spain = await strapi.entityService.findMany('api::spain.spain', {
+      filters: { active: true },
+      populate: {
+        image: true,
+        gallery: true
+      }
+    });
+
+    return spain;
+  },
+
+  // Método para obtener estadísticas específicas
+  async findStatistics() {
+    const spain = await strapi.entityService.findMany('api::spain.spain', {
+      filters: { active: true }
+    });
+
+    return spain.map(item => ({
+      id: item.id,
+      statistics: item.statistics,
+      statisticsTitle: item.statisticsTitle
+    }));
+  },
+
+  // Método para obtener tips de viaje específicos
+  async findTravelTips() {
+    const spain = await strapi.entityService.findMany('api::spain.spain', {
+      filters: { active: true }
+    });
+
+    return spain.map(item => ({
+      id: item.id,
+      travelTips: item.travelTips,
+      travelTipsTitle: item.travelTipsTitle
+    }));
+  },
+
+  // Método para obtener características específicas
+  async findFeatures() {
+    const spain = await strapi.entityService.findMany('api::spain.spain', {
+      filters: { active: true }
+    });
+
+    return spain.map(item => ({
+      id: item.id,
+      features: item.features,
+      featuresTitle: item.featuresTitle
+    }));
+  },
+
+  // Método para obtener información de programas
+  async findPrograms() {
+    const spain = await strapi.entityService.findMany('api::spain.spain', {
+      filters: { active: true }
+    });
+
+    return spain.map(item => ({
+      id: item.id,
+      programs: item.programs,
+      requirements: item.requirements
+    }));
+  }
+}));

--- a/src/api/thailand/content-types/thailand/schema.json
+++ b/src/api/thailand/content-types/thailand/schema.json
@@ -1,0 +1,209 @@
+{
+  "kind": "collectionType",
+  "collectionName": "thailands",
+  "info": {
+    "singularName": "thailand",
+    "pluralName": "thailands",
+    "displayName": "Thailand",
+    "description": "Información detallada sobre Tailandia como destino de estudio y trabajo"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "title": {
+      "type": "string",
+      "required": true,
+      "maxLength": 255,
+      "default": "Thailand"
+    },
+    "slug": {
+      "type": "uid",
+      "targetField": "title",
+      "required": true
+    },
+    "description": {
+      "type": "richtext",
+      "required": true
+    },
+    "shortDescription": {
+      "type": "text",
+      "maxLength": 500
+    },
+    "image": {
+      "type": "media",
+      "multiple": false,
+      "required": true,
+      "allowedTypes": ["images"]
+    },
+    "gallery": {
+      "type": "media",
+      "multiple": true,
+      "allowedTypes": ["images"]
+    },
+    "whyChooseTitle": {
+      "type": "string",
+      "default": "¿Por qué elegir Tailandia?"
+    },
+    "whyChooseItems": {
+      "type": "json"
+    },
+    "hospitalityTitle": {
+      "type": "string",
+      "default": "Hospitalidad Tailandesa"
+    },
+    "hospitalityDescription": {
+      "type": "string",
+      "default": "Experiencia en la famosa hospitalidad tailandesa y turismo"
+    },
+    "hospitalityIcon": {
+      "type": "string",
+      "default": "🙏"
+    },
+    "educationTitle": {
+      "type": "string",
+      "default": "Cultura Rica"
+    },
+    "educationDescription": {
+      "type": "string",
+      "default": "Inmersión en una de las culturas más fascinantes del mundo"
+    },
+    "educationIcon": {
+      "type": "string",
+      "default": "🏛️"
+    },
+    "cultureTitle": {
+      "type": "string",
+      "default": "Costo de Vida Bajo"
+    },
+    "cultureDescription": {
+      "type": "string",
+      "default": "Excelente relación calidad-precio para vivir y estudiar"
+    },
+    "cultureIcon": {
+      "type": "string",
+      "default": "💰"
+    },
+    "languageTitle": {
+      "type": "string",
+      "default": "Aprendizaje de Idiomas"
+    },
+    "languageDescription": {
+      "type": "string",
+      "default": "Mejora tu inglés y aprende tailandés básico"
+    },
+    "languageIcon": {
+      "type": "string",
+      "default": "🗣️"
+    },
+    "qualityTitle": {
+      "type": "string",
+      "default": "Aventura y Naturaleza"
+    },
+    "qualityDescription": {
+      "type": "string",
+      "default": "Playas paradisíacas, montañas y selvas tropicales"
+    },
+    "qualityIcon": {
+      "type": "string",
+      "default": "🏝️"
+    },
+    "opportunitiesTitle": {
+      "type": "string",
+      "default": "Oportunidades de Negocio"
+    },
+    "opportunitiesDescription": {
+      "type": "string",
+      "default": "Centro de negocios en el sudeste asiático"
+    },
+    "opportunitiesIcon": {
+      "type": "string",
+      "default": "💼"
+    },
+    "statisticsTitle": {
+      "type": "string",
+      "default": "Tailandia en números"
+    },
+    "statistics": {
+      "type": "json"
+    },
+    "featuresTitle": {
+      "type": "string",
+      "default": "Características de Tailandia"
+    },
+    "features": {
+      "type": "json"
+    },
+    "travelTipsTitle": {
+      "type": "string",
+      "default": "Tips de viaje para Tailandia"
+    },
+    "travelTips": {
+      "type": "json"
+    },
+    "programs": {
+      "type": "json"
+    },
+    "requirements": {
+      "type": "json"
+    },
+    "overview": {
+      "type": "json"
+    },
+    "highlights": {
+      "type": "json"
+    },
+    "pricing": {
+      "type": "json"
+    },
+    "accommodation": {
+      "type": "json"
+    },
+    "transportation": {
+      "type": "json"
+    },
+    "climate": {
+      "type": "json"
+    },
+    "culture": {
+      "type": "json"
+    },
+    "education": {
+      "type": "json"
+    },
+    "workOpportunities": {
+      "type": "json"
+    },
+    "visaInfo": {
+      "type": "json"
+    },
+    "costOfLiving": {
+      "type": "json"
+    },
+    "safety": {
+      "type": "json"
+    },
+    "attractions": {
+      "type": "json"
+    },
+    "events": {
+      "type": "json"
+    },
+    "testimonials": {
+      "type": "json"
+    },
+    "faq": {
+      "type": "json"
+    },
+    "seoTitle": {
+      "type": "string"
+    },
+    "seoDescription": {
+      "type": "text"
+    },
+    "seoKeywords": {
+      "type": "json"
+    }
+  }
+}

--- a/src/api/thailand/controllers/thailand.js
+++ b/src/api/thailand/controllers/thailand.js
@@ -1,0 +1,94 @@
+'use strict';
+
+/**
+ * thailand controller
+ */
+
+const { createCoreController } = require('@strapi/strapi').factories;
+
+module.exports = createCoreController('api::thailand.thailand', ({ strapi }) => ({
+  // Método personalizado para obtener información completa de Tailandia
+  async findComplete(ctx) {
+    const entities = await strapi.entityService.findMany('api::thailand.thailand', {
+      filters: { active: true },
+      populate: {
+        image: true,
+        gallery: true
+      }
+    });
+
+    return entities;
+  },
+
+  // Método personalizado para obtener estadísticas de Tailandia
+  async findStats(ctx) {
+    const entities = await strapi.entityService.findMany('api::thailand.thailand', {
+      filters: { active: true },
+      populate: {
+        image: true
+      }
+    });
+
+    // Retornar solo las estadísticas
+    return entities.map(entity => ({
+      id: entity.id,
+      title: entity.title,
+      statistics: entity.statistics,
+      statisticsTitle: entity.statisticsTitle
+    }));
+  },
+
+  // Método personalizado para obtener tips de viaje
+  async findTravelTips(ctx) {
+    const entities = await strapi.entityService.findMany('api::thailand.thailand', {
+      filters: { active: true },
+      populate: {
+        image: true
+      }
+    });
+
+    // Retornar solo los tips de viaje
+    return entities.map(entity => ({
+      id: entity.id,
+      title: entity.title,
+      travelTips: entity.travelTips,
+      travelTipsTitle: entity.travelTipsTitle
+    }));
+  },
+
+  // Método personalizado para obtener características de Tailandia
+  async findFeatures(ctx) {
+    const entities = await strapi.entityService.findMany('api::thailand.thailand', {
+      filters: { active: true },
+      populate: {
+        image: true
+      }
+    });
+
+    // Retornar solo las características
+    return entities.map(entity => ({
+      id: entity.id,
+      title: entity.title,
+      features: entity.features,
+      featuresTitle: entity.featuresTitle
+    }));
+  },
+
+  // Método personalizado para obtener información de programas
+  async findPrograms(ctx) {
+    const entities = await strapi.entityService.findMany('api::thailand.thailand', {
+      filters: { active: true },
+      populate: {
+        image: true
+      }
+    });
+
+    // Retornar solo la información de programas
+    return entities.map(entity => ({
+      id: entity.id,
+      title: entity.title,
+      programs: entity.programs,
+      requirements: entity.requirements
+    }));
+  }
+}));

--- a/src/api/thailand/routes/custom-routes.js
+++ b/src/api/thailand/routes/custom-routes.js
@@ -1,0 +1,50 @@
+'use strict';
+
+/**
+ * Custom routes for thailand
+ */
+
+module.exports = {
+  routes: [
+    {
+      method: 'GET',
+      path: '/thailands/complete',
+      handler: 'thailand.findComplete',
+      config: {
+        auth: false,
+      },
+    },
+    {
+      method: 'GET',
+      path: '/thailands/stats',
+      handler: 'thailand.findStats',
+      config: {
+        auth: false,
+      },
+    },
+    {
+      method: 'GET',
+      path: '/thailands/travel-tips',
+      handler: 'thailand.findTravelTips',
+      config: {
+        auth: false,
+      },
+    },
+    {
+      method: 'GET',
+      path: '/thailands/features',
+      handler: 'thailand.findFeatures',
+      config: {
+        auth: false,
+      },
+    },
+    {
+      method: 'GET',
+      path: '/thailands/programs',
+      handler: 'thailand.findPrograms',
+      config: {
+        auth: false,
+      },
+    },
+  ],
+};

--- a/src/api/thailand/routes/thailand.js
+++ b/src/api/thailand/routes/thailand.js
@@ -1,0 +1,37 @@
+'use strict';
+
+/**
+ * thailand router
+ */
+
+const { createCoreRouter } = require('@strapi/strapi').factories;
+
+module.exports = createCoreRouter('api::thailand.thailand', {
+  config: {
+    find: {
+      auth: false,
+      policies: [],
+      middlewares: [],
+    },
+    findOne: {
+      auth: false,
+      policies: [],
+      middlewares: [],
+    },
+    create: {
+      auth: {
+        strategy: 'jwt',
+      },
+    },
+    update: {
+      auth: {
+        strategy: 'jwt',
+      },
+    },
+    delete: {
+      auth: {
+        strategy: 'jwt',
+      },
+    },
+  },
+});

--- a/src/api/thailand/sample-data.json
+++ b/src/api/thailand/sample-data.json
@@ -1,0 +1,272 @@
+{
+  "thailandData": [
+    {
+      "title": "Thailand",
+      "slug": "thailand",
+      "description": "Descubre Tailandia, un país que combina tradición milenaria con modernidad. Oportunidades únicas en turismo, hospitalidad, enseñanza de inglés y negocios en el corazón del sudeste asiático.",
+      "shortDescription": "Experiencia única en turismo, cultura tailandesa y oportunidades de negocio",
+      "featured": true,
+      "active": true,
+      "whyChooseTitle": "¿Por qué elegir Tailandia?",
+      "whyChooseItems": [
+        {
+          "title": "Hospitalidad Tailandesa",
+          "description": "Experiencia en la famosa hospitalidad tailandesa y turismo",
+          "icon": "🙏"
+        },
+        {
+          "title": "Cultura Rica",
+          "description": "Inmersión en una de las culturas más fascinantes del mundo",
+          "icon": "🏛️"
+        },
+        {
+          "title": "Costo de Vida Bajo",
+          "description": "Excelente relación calidad-precio para vivir y estudiar",
+          "icon": "💰"
+        },
+        {
+          "title": "Aprendizaje de Idiomas",
+          "description": "Mejora tu inglés y aprende tailandés básico",
+          "icon": "🗣️"
+        },
+        {
+          "title": "Aventura y Naturaleza",
+          "description": "Playas paradisíacas, montañas y selvas tropicales",
+          "icon": "🏝️"
+        },
+        {
+          "title": "Oportunidades de Negocio",
+          "description": "Centro de negocios en el sudeste asiático",
+          "icon": "💼"
+        }
+      ],
+      "statisticsTitle": "Tailandia en números",
+      "statistics": [
+        {
+          "value": "70M+",
+          "label": "Habitantes"
+        },
+        {
+          "value": "40M+",
+          "label": "Turistas anuales"
+        },
+        {
+          "value": "95%",
+          "label": "Budistas"
+        },
+        {
+          "value": "1,000+",
+          "label": "Islas"
+        }
+      ],
+      "featuresTitle": "Características de Tailandia",
+      "features": [
+        {
+          "title": "Hospitalidad Tailandesa",
+          "description": "Famosa por su servicio excepcional y sonrisa tailandesa",
+          "icon": "🙏"
+        },
+        {
+          "title": "Cultura Milenaria",
+          "description": "Templos antiguos, tradiciones budistas y arte tradicional",
+          "icon": "🏛️"
+        },
+        {
+          "title": "Naturaleza Exuberante",
+          "description": "Playas tropicales, montañas y selvas vírgenes",
+          "icon": "🏝️"
+        },
+        {
+          "title": "Gastronomía Mundial",
+          "description": "Una de las cocinas más reconocidas internacionalmente",
+          "icon": "🍜"
+        }
+      ],
+      "travelTipsTitle": "Tips de viaje para Tailandia",
+      "travelTips": [
+        {
+          "title": "Visa de Trabajo",
+          "description": "Proceso de visa relativamente sencillo para trabajos calificados."
+        },
+        {
+          "title": "Cultura Local",
+          "description": "Respeta las tradiciones budistas y la monarquía tailandesa."
+        },
+        {
+          "title": "Clima Tropical",
+          "description": "Preparación para clima cálido y húmedo todo el año."
+        },
+        {
+          "title": "Transporte",
+          "description": "Sistema de transporte público eficiente y económico."
+        }
+      ],
+      "programs": [
+        "work-and-study",
+        "internship",
+        "volunteer"
+      ],
+      "requirements": [
+        "Nivel de inglés B1+",
+        "Experiencia en turismo o enseñanza",
+        "Mayor de 21 años",
+        "Título universitario preferible"
+      ],
+      "overview": {
+        "highlights": [
+          {
+            "title": "Hospitalidad Tailandesa",
+            "description": "Experiencia en la famosa hospitalidad tailandesa y turismo",
+            "icon": "Heart"
+          },
+          {
+            "title": "Cultura Rica",
+            "description": "Inmersión en una de las culturas más fascinantes del mundo",
+            "icon": "Temple"
+          },
+          {
+            "title": "Costo de Vida Bajo",
+            "description": "Excelente relación calidad-precio para vivir y estudiar",
+            "icon": "DollarSign"
+          }
+        ],
+        "features": [
+          {
+            "title": "Aprendizaje de Idiomas",
+            "description": "Mejora tu inglés y aprende tailandés básico"
+          },
+          {
+            "title": "Aventura y Naturaleza",
+            "description": "Playas paradisíacas, montañas y selvas tropicales"
+          },
+          {
+            "title": "Oportunidades de Negocio",
+            "description": "Centro de negocios en el sudeste asiático"
+          }
+        ]
+      },
+      "pricing": {
+        "accommodation": "200-500 USD/mes",
+        "food": "150-300 USD/mes",
+        "transportation": "50-100 USD/mes",
+        "medicalInsurance": "30-50 USD/mes",
+        "visaFee": "50-100 USD",
+        "languageCourse": "200-400 USD/mes"
+      },
+      "accommodation": {
+        "sharedAccommodation": "200-400 USD/mes",
+        "privateAccommodation": "400-800 USD/mes",
+        "hotelStaff": "Alojamiento incluido",
+        "apartment": "300-600 USD/mes"
+      },
+      "transportation": {
+        "publicTransport": "Sistema de BTS, MRT y autobuses",
+        "taxi": "Muy económico y disponible",
+        "tukTuk": "Experiencia local única",
+        "motorbike": "Opcional, 50-100 USD/mes"
+      },
+      "climate": {
+        "description": "Clima tropical con estación seca y lluviosa",
+        "temperature": "25-35°C promedio anual",
+        "rainfall": "Lluvias abundantes de mayo a octubre",
+        "seasons": "Estación seca (noviembre-abril) y lluviosa (mayo-octubre)"
+      },
+      "culture": {
+        "language": "Tailandés (oficial) e Inglés (ampliamente hablado)",
+        "religion": "Budismo (95%)",
+        "traditions": "Templos budistas, festivales tradicionales, arte tailandés",
+        "festivals": "Songkran (Año Nuevo), Loi Krathong, Visakha Bucha"
+      },
+      "education": {
+        "universities": "Universidades internacionales y locales",
+        "languageSchools": "Cursos de tailandés e inglés disponibles",
+        "quality": "Educación de calidad con opciones internacionales",
+        "costs": "Muy accesible comparado con otros países"
+      },
+      "workOpportunities": {
+        "fullTime": "Posiciones en turismo, enseñanza y negocios",
+        "sectors": "Turismo, hospitalidad, enseñanza de inglés, exportación",
+        "minimumWage": "Salario competitivo para extranjeros",
+        "networking": "Excelentes oportunidades de networking regional"
+      },
+      "visaInfo": {
+        "type": "Visa de Trabajo",
+        "duration": "Hasta 1 año (renovable)",
+        "requirements": "Contrato de trabajo, certificados médicos, antecedentes penales",
+        "processingTime": "1-2 semanas"
+      },
+      "costOfLiving": {
+        "monthly": "500-1000 USD",
+        "accommodation": "200-500 USD/mes",
+        "food": "150-300 USD/mes",
+        "transport": "50-100 USD/mes",
+        "entertainment": "100-200 USD/mes"
+      },
+      "safety": {
+        "level": "Seguro en general",
+        "crimeRate": "Baja en áreas turísticas",
+        "emergency": "191 (policía), 1669 (ambulancia)",
+        "tips": "Evitar áreas conflictivas y respetar la cultura local"
+      },
+      "attractions": [
+        "Templo del Buda de Esmeralda",
+        "Wat Pho",
+        "Islas Phi Phi",
+        "Chiang Mai",
+        "Mercado flotante de Damnoen Saduak",
+        "Parque Nacional de Khao Yai"
+      ],
+      "events": [
+        "Songkran (13-15 de abril)",
+        "Loi Krathong (noviembre)",
+        "Festival de las Luces",
+        "Carnaval de Pattaya",
+        "Festival de Comida de Bangkok"
+      ],
+      "testimonials": [
+        {
+          "name": "María González",
+          "content": "Mi experiencia en Tailandia fue increíble. La cultura, la gente y las oportunidades de trabajo son únicas.",
+          "program": "Work and Study",
+          "rating": 5
+        },
+        {
+          "name": "Carlos Rodríguez",
+          "content": "Trabajar en el sector turístico en Bangkok me permitió crecer profesionalmente y conocer Asia.",
+          "program": "Internship",
+          "rating": 5
+        }
+      ],
+      "faq": [
+        {
+          "question": "¿Necesito visa para trabajar en Tailandia?",
+          "answer": "Sí, necesitas una visa de trabajo que generalmente gestiona tu empleador. Te ayudamos con todo el proceso."
+        },
+        {
+          "question": "¿Puedo trabajar en Tailandia sin experiencia previa?",
+          "answer": "Se requiere experiencia previa en turismo o enseñanza, pero también ofrecemos programas de formación."
+        },
+        {
+          "question": "¿Qué nivel de inglés necesito?",
+          "answer": "Recomendamos nivel B1 o superior, ya que el inglés es ampliamente hablado en el sector turístico."
+        },
+        {
+          "question": "¿Es caro vivir en Tailandia?",
+          "answer": "Tailandia tiene uno de los costos de vida más bajos del sudeste asiático, muy accesible para extranjeros."
+        }
+      ],
+      "seoTitle": "Trabaja y Estudia en Tailandia - Programas Internacionales",
+      "seoDescription": "Descubre las mejores oportunidades de trabajo y estudio en Tailandia. Programas de turismo, hospitalidad y cultura tailandesa.",
+      "seoKeywords": [
+        "Tailandia",
+        "trabajar en Tailandia",
+        "estudiar en Tailandia",
+        "turismo Tailandia",
+        "cultura tailandesa",
+        "visa de trabajo",
+        "Bangkok",
+        "Chiang Mai"
+      ]
+    }
+  ]
+}

--- a/src/api/thailand/services/thailand.js
+++ b/src/api/thailand/services/thailand.js
@@ -1,0 +1,74 @@
+'use strict';
+
+/**
+ * thailand service
+ */
+
+const { createCoreService } = require('@strapi/strapi').factories;
+
+module.exports = createCoreService('api::thailand.thailand', ({ strapi }) => ({
+  // Método personalizado para obtener información completa de Tailandia
+  async findCompleteInfo() {
+    const thailand = await strapi.entityService.findMany('api::thailand.thailand', {
+      filters: { active: true },
+      populate: {
+        image: true,
+        gallery: true
+      }
+    });
+
+    return thailand;
+  },
+
+  // Método para obtener estadísticas específicas
+  async findStatistics() {
+    const thailand = await strapi.entityService.findMany('api::thailand.thailand', {
+      filters: { active: true }
+    });
+
+    return thailand.map(item => ({
+      id: item.id,
+      statistics: item.statistics,
+      statisticsTitle: item.statisticsTitle
+    }));
+  },
+
+  // Método para obtener tips de viaje específicos
+  async findTravelTips() {
+    const thailand = await strapi.entityService.findMany('api::thailand.thailand', {
+      filters: { active: true }
+    });
+
+    return thailand.map(item => ({
+      id: item.id,
+      travelTips: item.travelTips,
+      travelTipsTitle: item.travelTipsTitle
+    }));
+  },
+
+  // Método para obtener características específicas
+  async findFeatures() {
+    const thailand = await strapi.entityService.findMany('api::thailand.thailand', {
+      filters: { active: true }
+    });
+
+    return thailand.map(item => ({
+      id: item.id,
+      features: item.features,
+      featuresTitle: item.featuresTitle
+    }));
+  },
+
+  // Método para obtener información de programas
+  async findPrograms() {
+    const thailand = await strapi.entityService.findMany('api::thailand.thailand', {
+      filters: { active: true }
+    });
+
+    return thailand.map(item => ({
+      id: item.id,
+      programs: item.programs,
+      requirements: item.requirements
+    }));
+  }
+}));

--- a/src/api/united-kingdom/content-types/united-kingdom/schema.json
+++ b/src/api/united-kingdom/content-types/united-kingdom/schema.json
@@ -1,0 +1,209 @@
+{
+  "kind": "collectionType",
+  "collectionName": "united_kingdoms",
+  "info": {
+    "singularName": "united-kingdom",
+    "pluralName": "united-kingdoms",
+    "displayName": "United Kingdom",
+    "description": "Información detallada sobre Reino Unido como destino de estudio y trabajo"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "title": {
+      "type": "string",
+      "required": true,
+      "maxLength": 255,
+      "default": "United Kingdom"
+    },
+    "slug": {
+      "type": "uid",
+      "targetField": "title",
+      "required": true
+    },
+    "description": {
+      "type": "richtext",
+      "required": true
+    },
+    "shortDescription": {
+      "type": "text",
+      "maxLength": 500
+    },
+    "image": {
+      "type": "media",
+      "multiple": false,
+      "required": true,
+      "allowedTypes": ["images"]
+    },
+    "gallery": {
+      "type": "media",
+      "multiple": true,
+      "allowedTypes": ["images"]
+    },
+    "whyChooseTitle": {
+      "type": "string",
+      "default": "¿Por qué elegir Reino Unido?"
+    },
+    "whyChooseItems": {
+      "type": "json"
+    },
+    "hospitalityTitle": {
+      "type": "string",
+      "default": "Historia Milenaria"
+    },
+    "hospitalityDescription": {
+      "type": "string",
+      "default": "País con rica historia y tradiciones ancestrales"
+    },
+    "hospitalityIcon": {
+      "type": "string",
+      "default": "🏰"
+    },
+    "educationTitle": {
+      "type": "string",
+      "default": "Educación de Excelencia"
+    },
+    "educationDescription": {
+      "type": "string",
+      "default": "Universidades de prestigio mundial"
+    },
+    "educationIcon": {
+      "type": "string",
+      "default": "🎓"
+    },
+    "cultureTitle": {
+      "type": "string",
+      "default": "Cultura Británica"
+    },
+    "cultureDescription": {
+      "type": "string",
+      "default": "Inmersión en la cultura británica y europea"
+    },
+    "cultureIcon": {
+      "type": "string",
+      "default": "🇬🇧"
+    },
+    "languageTitle": {
+      "type": "string",
+      "default": "Idioma Inglés"
+    },
+    "languageDescription": {
+      "type": "string",
+      "default": "Inglés como idioma oficial en su cuna"
+    },
+    "languageIcon": {
+      "type": "string",
+      "default": "🗣️"
+    },
+    "qualityTitle": {
+      "type": "string",
+      "default": "Calidad de Vida"
+    },
+    "qualityDescription": {
+      "type": "string",
+      "default": "Excelente calidad de vida y servicios públicos"
+    },
+    "qualityIcon": {
+      "type": "string",
+      "default": "🏠"
+    },
+    "opportunitiesTitle": {
+      "type": "string",
+      "default": "Oportunidades Profesionales"
+    },
+    "opportunitiesDescription": {
+      "type": "string",
+      "default": "Carrera en empresas multinacionales y startups"
+    },
+    "opportunitiesIcon": {
+      "type": "string",
+      "default": "💼"
+    },
+    "statisticsTitle": {
+      "type": "string",
+      "default": "Reino Unido en números"
+    },
+    "statistics": {
+      "type": "json"
+    },
+    "featuresTitle": {
+      "type": "string",
+      "default": "Características del Reino Unido"
+    },
+    "features": {
+      "type": "json"
+    },
+    "travelTipsTitle": {
+      "type": "string",
+      "default": "Tips de viaje para Reino Unido"
+    },
+    "travelTips": {
+      "type": "json"
+    },
+    "programs": {
+      "type": "json"
+    },
+    "requirements": {
+      "type": "json"
+    },
+    "overview": {
+      "type": "json"
+    },
+    "highlights": {
+      "type": "json"
+    },
+    "pricing": {
+      "type": "json"
+    },
+    "accommodation": {
+      "type": "json"
+    },
+    "transportation": {
+      "type": "json"
+    },
+    "climate": {
+      "type": "json"
+    },
+    "culture": {
+      "type": "json"
+    },
+    "education": {
+      "type": "json"
+    },
+    "workOpportunities": {
+      "type": "json"
+    },
+    "visaInfo": {
+      "type": "json"
+    },
+    "costOfLiving": {
+      "type": "json"
+    },
+    "safety": {
+      "type": "json"
+    },
+    "attractions": {
+      "type": "json"
+    },
+    "events": {
+      "type": "json"
+    },
+    "testimonials": {
+      "type": "json"
+    },
+    "faq": {
+      "type": "json"
+    },
+    "seoTitle": {
+      "type": "string"
+    },
+    "seoDescription": {
+      "type": "text"
+    },
+    "seoKeywords": {
+      "type": "json"
+    }
+  }
+}

--- a/src/api/united-kingdom/controllers/united-kingdom.js
+++ b/src/api/united-kingdom/controllers/united-kingdom.js
@@ -1,0 +1,94 @@
+'use strict';
+
+/**
+ * united-kingdom controller
+ */
+
+const { createCoreController } = require('@strapi/strapi').factories;
+
+module.exports = createCoreController('api::united-kingdom.united-kingdom', ({ strapi }) => ({
+  // Método personalizado para obtener información completa del Reino Unido
+  async findComplete(ctx) {
+    const entities = await strapi.entityService.findMany('api::united-kingdom.united-kingdom', {
+      filters: { active: true },
+      populate: {
+        image: true,
+        gallery: true
+      }
+    });
+
+    return entities;
+  },
+
+  // Método personalizado para obtener estadísticas del Reino Unido
+  async findStats(ctx) {
+    const entities = await strapi.entityService.findMany('api::united-kingdom.united-kingdom', {
+      filters: { active: true },
+      populate: {
+        image: true
+      }
+    });
+
+    // Retornar solo las estadísticas
+    return entities.map(entity => ({
+      id: entity.id,
+      title: entity.title,
+      statistics: entity.statistics,
+      statisticsTitle: entity.statisticsTitle
+    }));
+  },
+
+  // Método personalizado para obtener tips de viaje
+  async findTravelTips(ctx) {
+    const entities = await strapi.entityService.findMany('api::united-kingdom.united-kingdom', {
+      filters: { active: true },
+      populate: {
+        image: true
+      }
+    });
+
+    // Retornar solo los tips de viaje
+    return entities.map(entity => ({
+      id: entity.id,
+      title: entity.title,
+      travelTips: entity.travelTips,
+      travelTipsTitle: entity.travelTipsTitle
+    }));
+  },
+
+  // Método personalizado para obtener características del Reino Unido
+  async findFeatures(ctx) {
+    const entities = await strapi.entityService.findMany('api::united-kingdom.united-kingdom', {
+      filters: { active: true },
+      populate: {
+        image: true
+      }
+    });
+
+    // Retornar solo las características
+    return entities.map(entity => ({
+      id: entity.id,
+      title: entity.title,
+      features: entity.features,
+      featuresTitle: entity.featuresTitle
+    }));
+  },
+
+  // Método personalizado para obtener información de programas
+  async findPrograms(ctx) {
+    const entities = await strapi.entityService.findMany('api::united-kingdom.united-kingdom', {
+      filters: { active: true },
+      populate: {
+        image: true
+      }
+    });
+
+    // Retornar solo la información de programas
+    return entities.map(entity => ({
+      id: entity.id,
+      title: entity.title,
+      programs: entity.programs,
+      requirements: entity.requirements
+    }));
+  }
+}));

--- a/src/api/united-kingdom/routes/custom-routes.js
+++ b/src/api/united-kingdom/routes/custom-routes.js
@@ -1,0 +1,50 @@
+'use strict';
+
+/**
+ * Custom routes for united-kingdom
+ */
+
+module.exports = {
+  routes: [
+    {
+      method: 'GET',
+      path: '/united-kingdoms/complete',
+      handler: 'united-kingdom.findComplete',
+      config: {
+        auth: false,
+      },
+    },
+    {
+      method: 'GET',
+      path: '/united-kingdoms/stats',
+      handler: 'united-kingdom.findStats',
+      config: {
+        auth: false,
+      },
+    },
+    {
+      method: 'GET',
+      path: '/united-kingdoms/travel-tips',
+      handler: 'united-kingdom.findTravelTips',
+      config: {
+        auth: false,
+      },
+    },
+    {
+      method: 'GET',
+      path: '/united-kingdoms/features',
+      handler: 'united-kingdom.findFeatures',
+      config: {
+        auth: false,
+      },
+    },
+    {
+      method: 'GET',
+      path: '/united-kingdoms/programs',
+      handler: 'united-kingdom.findPrograms',
+      config: {
+        auth: false,
+      },
+    },
+  ],
+};

--- a/src/api/united-kingdom/routes/united-kingdom.js
+++ b/src/api/united-kingdom/routes/united-kingdom.js
@@ -1,0 +1,37 @@
+'use strict';
+
+/**
+ * united-kingdom router
+ */
+
+const { createCoreRouter } = require('@strapi/strapi').factories;
+
+module.exports = createCoreRouter('api::united-kingdom.united-kingdom', {
+  config: {
+    find: {
+      auth: false,
+      policies: [],
+      middlewares: [],
+    },
+    findOne: {
+      auth: false,
+      policies: [],
+      middlewares: [],
+    },
+    create: {
+      auth: {
+        strategy: 'jwt',
+      },
+    },
+    update: {
+      auth: {
+        strategy: 'jwt',
+      },
+    },
+    delete: {
+      auth: {
+        strategy: 'jwt',
+      },
+    },
+  },
+});

--- a/src/api/united-kingdom/services/united-kingdom.js
+++ b/src/api/united-kingdom/services/united-kingdom.js
@@ -1,0 +1,74 @@
+'use strict';
+
+/**
+ * united-kingdom service
+ */
+
+const { createCoreService } = require('@strapi/strapi').factories;
+
+module.exports = createCoreService('api::united-kingdom.united-kingdom', ({ strapi }) => ({
+  // Método personalizado para obtener información completa del Reino Unido
+  async findCompleteInfo() {
+    const unitedKingdom = await strapi.entityService.findMany('api::united-kingdom.united-kingdom', {
+      filters: { active: true },
+      populate: {
+        image: true,
+        gallery: true
+      }
+    });
+
+    return unitedKingdom;
+  },
+
+  // Método para obtener estadísticas específicas
+  async findStatistics() {
+    const unitedKingdom = await strapi.entityService.findMany('api::united-kingdom.united-kingdom', {
+      filters: { active: true }
+    });
+
+    return unitedKingdom.map(item => ({
+      id: item.id,
+      statistics: item.statistics,
+      statisticsTitle: item.statisticsTitle
+    }));
+  },
+
+  // Método para obtener tips de viaje específicos
+  async findTravelTips() {
+    const unitedKingdom = await strapi.entityService.findMany('api::united-kingdom.united-kingdom', {
+      filters: { active: true }
+    });
+
+    return unitedKingdom.map(item => ({
+      id: item.id,
+      travelTips: item.travelTips,
+      travelTipsTitle: item.travelTipsTitle
+    }));
+  },
+
+  // Método para obtener características específicas
+  async findFeatures() {
+    const unitedKingdom = await strapi.entityService.findMany('api::united-kingdom.united-kingdom', {
+      filters: { active: true }
+    });
+
+    return unitedKingdom.map(item => ({
+      id: item.id,
+      features: item.features,
+      featuresTitle: item.featuresTitle
+    }));
+  },
+
+  // Método para obtener información de programas
+  async findPrograms() {
+    const unitedKingdom = await strapi.entityService.findMany('api::united-kingdom.united-kingdom', {
+      filters: { active: true }
+    });
+
+    return unitedKingdom.map(item => ({
+      id: item.id,
+      programs: item.programs,
+      requirements: item.requirements
+    }));
+  }
+}));

--- a/src/api/united-state/content-types/united-state/schema.json
+++ b/src/api/united-state/content-types/united-state/schema.json
@@ -1,0 +1,209 @@
+{
+  "kind": "collectionType",
+  "collectionName": "united_states",
+  "info": {
+    "singularName": "united-state",
+    "pluralName": "united-states",
+    "displayName": "United States",
+    "description": "Información detallada sobre Estados Unidos como destino de estudio y trabajo"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "title": {
+      "type": "string",
+      "required": true,
+      "maxLength": 255,
+      "default": "United States"
+    },
+    "slug": {
+      "type": "uid",
+      "targetField": "title",
+      "required": true
+    },
+    "description": {
+      "type": "richtext",
+      "required": true
+    },
+    "shortDescription": {
+      "type": "text",
+      "maxLength": 500
+    },
+    "image": {
+      "type": "media",
+      "multiple": false,
+      "required": true,
+      "allowedTypes": ["images"]
+    },
+    "gallery": {
+      "type": "media",
+      "multiple": true,
+      "allowedTypes": ["images"]
+    },
+    "whyChooseTitle": {
+      "type": "string",
+      "default": "¿Por qué elegir Estados Unidos?"
+    },
+    "whyChooseItems": {
+      "type": "json"
+    },
+    "hospitalityTitle": {
+      "type": "string",
+      "default": "Educación de Excelencia"
+    },
+    "hospitalityDescription": {
+      "type": "string",
+      "default": "Universidades de prestigio mundial"
+    },
+    "hospitalityIcon": {
+      "type": "string",
+      "default": "🎓"
+    },
+    "educationTitle": {
+      "type": "string",
+      "default": "Oportunidades Profesionales"
+    },
+    "educationDescription": {
+      "type": "string",
+      "default": "Carrera en empresas multinacionales y startups"
+    },
+    "educationIcon": {
+      "type": "string",
+      "default": "💼"
+    },
+    "cultureTitle": {
+      "type": "string",
+      "default": "Cultura Diversa"
+    },
+    "cultureDescription": {
+      "type": "string",
+      "default": "País multicultural con diversidad étnica"
+    },
+    "cultureIcon": {
+      "type": "string",
+      "default": "🌍"
+    },
+    "languageTitle": {
+      "type": "string",
+      "default": "Idioma Inglés"
+    },
+    "languageDescription": {
+      "type": "string",
+      "default": "Inglés como idioma oficial en su cuna"
+    },
+    "languageIcon": {
+      "type": "string",
+      "default": "🗣️"
+    },
+    "qualityTitle": {
+      "type": "string",
+      "default": "Calidad de Vida"
+    },
+    "qualityDescription": {
+      "type": "string",
+      "default": "Excelente calidad de vida y servicios públicos"
+    },
+    "qualityIcon": {
+      "type": "string",
+      "default": "🏠"
+    },
+    "opportunitiesTitle": {
+      "type": "string",
+      "default": "Innovación Tecnológica"
+    },
+    "opportunitiesDescription": {
+      "type": "string",
+      "default": "Hub tecnológico mundial con oportunidades únicas"
+    },
+    "opportunitiesIcon": {
+      "type": "string",
+      "default": "💻"
+    },
+    "statisticsTitle": {
+      "type": "string",
+      "default": "Estados Unidos en números"
+    },
+    "statistics": {
+      "type": "json"
+    },
+    "featuresTitle": {
+      "type": "string",
+      "default": "Características de Estados Unidos"
+    },
+    "features": {
+      "type": "json"
+    },
+    "travelTipsTitle": {
+      "type": "string",
+      "default": "Tips de viaje para Estados Unidos"
+    },
+    "travelTips": {
+      "type": "json"
+    },
+    "programs": {
+      "type": "json"
+    },
+    "requirements": {
+      "type": "json"
+    },
+    "overview": {
+      "type": "json"
+    },
+    "highlights": {
+      "type": "json"
+    },
+    "pricing": {
+      "type": "json"
+    },
+    "accommodation": {
+      "type": "json"
+    },
+    "transportation": {
+      "type": "json"
+    },
+    "climate": {
+      "type": "json"
+    },
+    "culture": {
+      "type": "json"
+    },
+    "education": {
+      "type": "json"
+    },
+    "workOpportunities": {
+      "type": "json"
+    },
+    "visaInfo": {
+      "type": "json"
+    },
+    "costOfLiving": {
+      "type": "json"
+    },
+    "safety": {
+      "type": "json"
+    },
+    "attractions": {
+      "type": "json"
+    },
+    "events": {
+      "type": "json"
+    },
+    "testimonials": {
+      "type": "json"
+    },
+    "faq": {
+      "type": "json"
+    },
+    "seoTitle": {
+      "type": "string"
+    },
+    "seoDescription": {
+      "type": "text"
+    },
+    "seoKeywords": {
+      "type": "json"
+    }
+  }
+}

--- a/src/api/united-state/controllers/united-state.js
+++ b/src/api/united-state/controllers/united-state.js
@@ -1,0 +1,94 @@
+'use strict';
+
+/**
+ * united-states controller
+ */
+
+const { createCoreController } = require('@strapi/strapi').factories;
+
+module.exports = createCoreController('api::united-state.united-state', ({ strapi }) => ({
+  // Método personalizado para obtener información completa de Estados Unidos
+  async findComplete(ctx) {
+    const entities = await strapi.entityService.findMany('api::united-state.united-state', {
+      filters: { active: true },
+      populate: {
+        image: true,
+        gallery: true
+      }
+    });
+
+    return entities;
+  },
+
+  // Método personalizado para obtener estadísticas de Estados Unidos
+  async findStats(ctx) {
+    const entities = await strapi.entityService.findMany('api::united-state.united-state', {
+      filters: { active: true },
+      populate: {
+        image: true
+      }
+    });
+
+    // Retornar solo las estadísticas
+    return entities.map(entity => ({
+      id: entity.id,
+      title: entity.title,
+      statistics: entity.statistics,
+      statisticsTitle: entity.statisticsTitle
+    }));
+  },
+
+  // Método personalizado para obtener tips de viaje
+  async findTravelTips(ctx) {
+    const entities = await strapi.entityService.findMany('api::united-state.united-state', {
+      filters: { active: true },
+      populate: {
+        image: true
+      }
+    });
+
+    // Retornar solo los tips de viaje
+    return entities.map(entity => ({
+      id: entity.id,
+      title: entity.title,
+      travelTips: entity.travelTips,
+      travelTipsTitle: entity.travelTipsTitle
+    }));
+  },
+
+  // Método personalizado para obtener características de Estados Unidos
+  async findFeatures(ctx) {
+    const entities = await strapi.entityService.findMany('api::united-state.united-state', {
+      filters: { active: true },
+      populate: {
+        image: true
+      }
+    });
+
+    // Retornar solo las características
+    return entities.map(entity => ({
+      id: entity.id,
+      title: entity.title,
+      features: entity.features,
+      featuresTitle: entity.featuresTitle
+    }));
+  },
+
+  // Método personalizado para obtener información de programas
+  async findPrograms(ctx) {
+    const entities = await strapi.entityService.findMany('api::united-state.united-state', {
+      filters: { active: true },
+      populate: {
+        image: true
+      }
+    });
+
+    // Retornar solo la información de programas
+    return entities.map(entity => ({
+      id: entity.id,
+      title: entity.title,
+      programs: entity.programs,
+      requirements: entity.requirements
+    }));
+  }
+}));

--- a/src/api/united-state/routes/custom-routes.js
+++ b/src/api/united-state/routes/custom-routes.js
@@ -1,0 +1,50 @@
+'use strict';
+
+/**
+ * Custom routes for united-states
+ */
+
+module.exports = {
+  routes: [
+    {
+      method: 'GET',
+      path: '/united-state/complete',
+      handler: 'united-state.findComplete',
+      config: {
+        auth: false,
+      },
+    },
+    {
+      method: 'GET',
+      path: '/united-state/stats',
+      handler: 'united-state.findStats',
+      config: {
+        auth: false,
+      },
+    },
+    {
+      method: 'GET',
+      path: '/united-state/travel-tips',
+      handler: 'united-state.findTravelTips',
+      config: {
+        auth: false,
+      },
+    },
+    {
+      method: 'GET',
+      path: '/united-state/features',
+      handler: 'united-state.findFeatures',
+      config: {
+        auth: false,
+      },
+    },
+    {
+      method: 'GET',
+      path: '/united-state/programs',
+      handler: 'united-state.findPrograms',
+      config: {
+        auth: false,
+      },
+    },
+  ],
+};

--- a/src/api/united-state/routes/united-state.js
+++ b/src/api/united-state/routes/united-state.js
@@ -1,0 +1,37 @@
+'use strict';
+
+/**
+ * united-states router
+ */
+
+const { createCoreRouter } = require('@strapi/strapi').factories;
+
+module.exports = createCoreRouter('api::united-state.united-state', {
+  config: {
+    find: {
+      auth: false,
+      policies: [],
+      middlewares: [],
+    },
+    findOne: {
+      auth: false,
+      policies: [],
+      middlewares: [],
+    },
+    create: {
+      auth: {
+        strategy: 'jwt',
+      },
+    },
+    update: {
+      auth: {
+        strategy: 'jwt',
+      },
+    },
+    delete: {
+      auth: {
+        strategy: 'jwt',
+      },
+    },
+  },
+});

--- a/src/api/united-state/services/united-state.js
+++ b/src/api/united-state/services/united-state.js
@@ -1,0 +1,74 @@
+'use strict';
+
+/**
+ * united-states service
+ */
+
+const { createCoreService } = require('@strapi/strapi').factories;
+
+module.exports = createCoreService('api::united-state.united-state', ({ strapi }) => ({
+  // Método personalizado para obtener información completa de Estados Unidos
+  async findCompleteInfo() {
+    const unitedStates = await strapi.entityService.findMany('api::united-state.united-state', {
+      filters: { active: true },
+      populate: {
+        image: true,
+        gallery: true
+      }
+    });
+
+    return unitedStates;
+  },
+
+  // Método para obtener estadísticas específicas
+  async findStatistics() {
+    const unitedStates = await strapi.entityService.findMany('api::united-state.united-state', {
+      filters: { active: true }
+    });
+
+    return unitedStates.map(item => ({
+      id: item.id,
+      statistics: item.statistics,
+      statisticsTitle: item.statisticsTitle
+    }));
+  },
+
+  // Método para obtener tips de viaje específicos
+  async findTravelTips() {
+    const unitedStates = await strapi.entityService.findMany('api::united-state.united-state', {
+      filters: { active: true }
+    });
+
+    return unitedStates.map(item => ({
+      id: item.id,
+      travelTips: item.travelTips,
+      travelTipsTitle: item.travelTipsTitle
+    }));
+  },
+
+  // Método para obtener características específicas
+  async findFeatures() {
+    const unitedStates = await strapi.entityService.findMany('api::united-state.united-state', {
+      filters: { active: true }
+    });
+
+    return unitedStates.map(item => ({
+      id: item.id,
+      features: item.features,
+      featuresTitle: item.featuresTitle
+    }));
+  },
+
+  // Método para obtener información de programas
+  async findPrograms() {
+    const unitedStates = await strapi.entityService.findMany('api::united-state.united-state', {
+      filters: { active: true }
+    });
+
+    return unitedStates.map(item => ({
+      id: item.id,
+      programs: item.programs,
+      requirements: item.requirements
+    }));
+  }
+}));

--- a/src/api/vietnam/content-types/vietnam/schema.json
+++ b/src/api/vietnam/content-types/vietnam/schema.json
@@ -1,0 +1,209 @@
+{
+  "kind": "collectionType",
+  "collectionName": "vietnams",
+  "info": {
+    "singularName": "vietnam",
+    "pluralName": "vietnams",
+    "displayName": "Vietnam",
+    "description": "Información detallada sobre Vietnam como destino de estudio y trabajo"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "title": {
+      "type": "string",
+      "required": true,
+      "maxLength": 255,
+      "default": "Vietnam"
+    },
+    "slug": {
+      "type": "uid",
+      "targetField": "title",
+      "required": true
+    },
+    "description": {
+      "type": "richtext",
+      "required": true
+    },
+    "shortDescription": {
+      "type": "text",
+      "maxLength": 500
+    },
+    "image": {
+      "type": "media",
+      "multiple": false,
+      "required": true,
+      "allowedTypes": ["images"]
+    },
+    "gallery": {
+      "type": "media",
+      "multiple": true,
+      "allowedTypes": ["images"]
+    },
+    "whyChooseTitle": {
+      "type": "string",
+      "default": "¿Por qué elegir Vietnam?"
+    },
+    "whyChooseItems": {
+      "type": "json"
+    },
+    "hospitalityTitle": {
+      "type": "string",
+      "default": "Cultura Milenaria"
+    },
+    "hospitalityDescription": {
+      "type": "string",
+      "default": "Inmersión en una de las culturas más ricas del sudeste asiático"
+    },
+    "hospitalityIcon": {
+      "type": "string",
+      "default": "🏛️"
+    },
+    "educationTitle": {
+      "type": "string",
+      "default": "Costo de Vida Bajo"
+    },
+    "educationDescription": {
+      "type": "string",
+      "default": "Excelente relación calidad-precio para vivir y estudiar"
+    },
+    "educationIcon": {
+      "type": "string",
+      "default": "💰"
+    },
+    "cultureTitle": {
+      "type": "string",
+      "default": "Gastronomía Mundial"
+    },
+    "cultureDescription": {
+      "type": "string",
+      "default": "Una de las cocinas más reconocidas internacionalmente"
+    },
+    "cultureIcon": {
+      "type": "string",
+      "default": "🍜"
+    },
+    "languageTitle": {
+      "type": "string",
+      "default": "Aprendizaje de Idiomas"
+    },
+    "languageDescription": {
+      "type": "string",
+      "default": "Mejora tu inglés y aprende vietnamita básico"
+    },
+    "languageIcon": {
+      "type": "string",
+      "default": "🗣️"
+    },
+    "qualityTitle": {
+      "type": "string",
+      "default": "Naturaleza Exuberante"
+    },
+    "qualityDescription": {
+      "type": "string",
+      "default": "Desde montañas hasta playas tropicales"
+    },
+    "qualityIcon": {
+      "type": "string",
+      "default": "🏔️"
+    },
+    "opportunitiesTitle": {
+      "type": "string",
+      "default": "Oportunidades de Negocio"
+    },
+    "opportunitiesDescription": {
+      "type": "string",
+      "default": "Economía en crecimiento con muchas oportunidades"
+    },
+    "opportunitiesIcon": {
+      "type": "string",
+      "default": "💼"
+    },
+    "statisticsTitle": {
+      "type": "string",
+      "default": "Vietnam en números"
+    },
+    "statistics": {
+      "type": "json"
+    },
+    "featuresTitle": {
+      "type": "string",
+      "default": "Características de Vietnam"
+    },
+    "features": {
+      "type": "json"
+    },
+    "travelTipsTitle": {
+      "type": "string",
+      "default": "Tips de viaje para Vietnam"
+    },
+    "travelTips": {
+      "type": "json"
+    },
+    "programs": {
+      "type": "json"
+    },
+    "requirements": {
+      "type": "json"
+    },
+    "overview": {
+      "type": "json"
+    },
+    "highlights": {
+      "type": "json"
+    },
+    "pricing": {
+      "type": "json"
+    },
+    "accommodation": {
+      "type": "json"
+    },
+    "transportation": {
+      "type": "json"
+    },
+    "climate": {
+      "type": "json"
+    },
+    "culture": {
+      "type": "json"
+    },
+    "education": {
+      "type": "json"
+    },
+    "workOpportunities": {
+      "type": "json"
+    },
+    "visaInfo": {
+      "type": "json"
+    },
+    "costOfLiving": {
+      "type": "json"
+    },
+    "safety": {
+      "type": "json"
+    },
+    "attractions": {
+      "type": "json"
+    },
+    "events": {
+      "type": "json"
+    },
+    "testimonials": {
+      "type": "json"
+    },
+    "faq": {
+      "type": "json"
+    },
+    "seoTitle": {
+      "type": "string"
+    },
+    "seoDescription": {
+      "type": "text"
+    },
+    "seoKeywords": {
+      "type": "json"
+    }
+  }
+}

--- a/src/api/vietnam/controllers/vietnam.js
+++ b/src/api/vietnam/controllers/vietnam.js
@@ -1,0 +1,94 @@
+'use strict';
+
+/**
+ * vietnam controller
+ */
+
+const { createCoreController } = require('@strapi/strapi').factories;
+
+module.exports = createCoreController('api::vietnam.vietnam', ({ strapi }) => ({
+  // Método personalizado para obtener información completa de Vietnam
+  async findComplete(ctx) {
+    const entities = await strapi.entityService.findMany('api::vietnam.vietnam', {
+      filters: { active: true },
+      populate: {
+        image: true,
+        gallery: true
+      }
+    });
+
+    return entities;
+  },
+
+  // Método personalizado para obtener estadísticas de Vietnam
+  async findStats(ctx) {
+    const entities = await strapi.entityService.findMany('api::vietnam.vietnam', {
+      filters: { active: true },
+      populate: {
+        image: true
+      }
+    });
+
+    // Retornar solo las estadísticas
+    return entities.map(entity => ({
+      id: entity.id,
+      title: entity.title,
+      statistics: entity.statistics,
+      statisticsTitle: entity.statisticsTitle
+    }));
+  },
+
+  // Método personalizado para obtener tips de viaje
+  async findTravelTips(ctx) {
+    const entities = await strapi.entityService.findMany('api::vietnam.vietnam', {
+      filters: { active: true },
+      populate: {
+        image: true
+      }
+    });
+
+    // Retornar solo los tips de viaje
+    return entities.map(entity => ({
+      id: entity.id,
+      title: entity.title,
+      travelTips: entity.travelTips,
+      travelTipsTitle: entity.travelTipsTitle
+    }));
+  },
+
+  // Método personalizado para obtener características de Vietnam
+  async findFeatures(ctx) {
+    const entities = await strapi.entityService.findMany('api::vietnam.vietnam', {
+      filters: { active: true },
+      populate: {
+        image: true
+      }
+    });
+
+    // Retornar solo las características
+    return entities.map(entity => ({
+      id: entity.id,
+      title: entity.title,
+      features: entity.features,
+      featuresTitle: entity.featuresTitle
+    }));
+  },
+
+  // Método personalizado para obtener información de programas
+  async findPrograms(ctx) {
+    const entities = await strapi.entityService.findMany('api::vietnam.vietnam', {
+      filters: { active: true },
+      populate: {
+        image: true
+      }
+    });
+
+    // Retornar solo la información de programas
+    return entities.map(entity => ({
+      id: entity.id,
+      title: entity.title,
+      programs: entity.programs,
+      requirements: entity.requirements
+    }));
+  }
+}));

--- a/src/api/vietnam/routes/custom-routes.js
+++ b/src/api/vietnam/routes/custom-routes.js
@@ -1,0 +1,50 @@
+'use strict';
+
+/**
+ * Custom routes for vietnam
+ */
+
+module.exports = {
+  routes: [
+    {
+      method: 'GET',
+      path: '/vietnams/complete',
+      handler: 'vietnam.findComplete',
+      config: {
+        auth: false,
+      },
+    },
+    {
+      method: 'GET',
+      path: '/vietnams/stats',
+      handler: 'vietnam.findStats',
+      config: {
+        auth: false,
+      },
+    },
+    {
+      method: 'GET',
+      path: '/vietnams/travel-tips',
+      handler: 'vietnam.findTravelTips',
+      config: {
+        auth: false,
+      },
+    },
+    {
+      method: 'GET',
+      path: '/vietnams/features',
+      handler: 'vietnam.findFeatures',
+      config: {
+        auth: false,
+      },
+    },
+    {
+      method: 'GET',
+      path: '/vietnams/programs',
+      handler: 'vietnam.findPrograms',
+      config: {
+        auth: false,
+      },
+    },
+  ],
+};

--- a/src/api/vietnam/routes/vietnam.js
+++ b/src/api/vietnam/routes/vietnam.js
@@ -1,0 +1,37 @@
+'use strict';
+
+/**
+ * vietnam router
+ */
+
+const { createCoreRouter } = require('@strapi/strapi').factories;
+
+module.exports = createCoreRouter('api::vietnam.vietnam', {
+  config: {
+    find: {
+      auth: false,
+      policies: [],
+      middlewares: [],
+    },
+    findOne: {
+      auth: false,
+      policies: [],
+      middlewares: [],
+    },
+    create: {
+      auth: {
+        strategy: 'jwt',
+      },
+    },
+    update: {
+      auth: {
+        strategy: 'jwt',
+      },
+    },
+    delete: {
+      auth: {
+        strategy: 'jwt',
+      },
+    },
+  },
+});

--- a/src/api/vietnam/sample-data.json
+++ b/src/api/vietnam/sample-data.json
@@ -1,0 +1,272 @@
+{
+  "vietnamData": [
+    {
+      "title": "Vietnam",
+      "slug": "vietnam",
+      "description": "Descubre Vietnam, un país que combina historia milenaria con modernidad. Oportunidades únicas en turismo, enseñanza de inglés, negocios y tecnología en uno de los destinos más fascinantes del sudeste asiático.",
+      "shortDescription": "Cultura milenaria con costo de vida bajo y oportunidades de negocio",
+      "featured": true,
+      "active": true,
+      "whyChooseTitle": "¿Por qué elegir Vietnam?",
+      "whyChooseItems": [
+        {
+          "title": "Cultura Milenaria",
+          "description": "Inmersión en una de las culturas más ricas del sudeste asiático",
+          "icon": "🏛️"
+        },
+        {
+          "title": "Costo de Vida Bajo",
+          "description": "Excelente relación calidad-precio para vivir y estudiar",
+          "icon": "💰"
+        },
+        {
+          "title": "Gastronomía Mundial",
+          "description": "Una de las cocinas más reconocidas internacionalmente",
+          "icon": "🍜"
+        },
+        {
+          "title": "Aprendizaje de Idiomas",
+          "description": "Mejora tu inglés y aprende vietnamita básico",
+          "icon": "🗣️"
+        },
+        {
+          "title": "Naturaleza Exuberante",
+          "description": "Desde montañas hasta playas tropicales",
+          "icon": "🏔️"
+        },
+        {
+          "title": "Oportunidades de Negocio",
+          "description": "Economía en crecimiento con muchas oportunidades",
+          "icon": "💼"
+        }
+      ],
+      "statisticsTitle": "Vietnam en números",
+      "statistics": [
+        {
+          "value": "97M+",
+          "label": "Habitantes"
+        },
+        {
+          "value": "15M+",
+          "label": "Turistas anuales"
+        },
+        {
+          "value": "95%",
+          "label": "Población urbana"
+        },
+        {
+          "value": "1,000+",
+          "label": "Años de historia"
+        }
+      ],
+      "featuresTitle": "Características de Vietnam",
+      "features": [
+        {
+          "title": "Cultura Milenaria",
+          "description": "Historia rica y tradiciones ancestrales",
+          "icon": "🏛️"
+        },
+        {
+          "title": "Gastronomía Mundial",
+          "description": "Una de las cocinas más reconocidas del mundo",
+          "icon": "🍜"
+        },
+        {
+          "title": "Naturaleza Exuberante",
+          "description": "Desde montañas hasta playas tropicales",
+          "icon": "🏔️"
+        },
+        {
+          "title": "Economía en Crecimiento",
+          "description": "Oportunidades de negocio y empleo",
+          "icon": "📈"
+        }
+      ],
+      "travelTipsTitle": "Tips de viaje para Vietnam",
+      "travelTips": [
+        {
+          "title": "Visa de Trabajo",
+          "description": "Proceso de visa relativamente sencillo para trabajos calificados."
+        },
+        {
+          "title": "Cultura Local",
+          "description": "Respeto por las tradiciones familiares y la cultura local."
+        },
+        {
+          "title": "Clima Tropical",
+          "description": "Preparación para clima cálido y húmedo con estaciones marcadas."
+        },
+        {
+          "title": "Transporte",
+          "description": "Sistema de transporte público eficiente y económico."
+        }
+      ],
+      "programs": [
+        "work-and-study",
+        "internship",
+        "volunteer"
+      ],
+      "requirements": [
+        "Nivel de inglés B1+",
+        "Experiencia en turismo o enseñanza",
+        "Mayor de 21 años",
+        "Título universitario preferible"
+      ],
+      "overview": {
+        "highlights": [
+          {
+            "title": "Cultura Milenaria",
+            "description": "Inmersión en una de las culturas más ricas del sudeste asiático",
+            "icon": "Temple"
+          },
+          {
+            "title": "Costo de Vida Bajo",
+            "description": "Excelente relación calidad-precio para vivir y estudiar",
+            "icon": "DollarSign"
+          },
+          {
+            "title": "Gastronomía Mundial",
+            "description": "Una de las cocinas más reconocidas internacionalmente",
+            "icon": "Utensils"
+          }
+        ],
+        "features": [
+          {
+            "title": "Aprendizaje de Idiomas",
+            "description": "Mejora tu inglés y aprende vietnamita básico"
+          },
+          {
+            "title": "Naturaleza Exuberante",
+            "description": "Desde montañas hasta playas tropicales"
+          },
+          {
+            "title": "Oportunidades de Negocio",
+            "description": "Economía en crecimiento con muchas oportunidades"
+          }
+        ]
+      },
+      "pricing": {
+        "accommodation": "200-500 USD/mes",
+        "food": "150-300 USD/mes",
+        "transportation": "50-100 USD/mes",
+        "medicalInsurance": "30-50 USD/mes",
+        "visaFee": "50-100 USD",
+        "languageCourse": "200-400 USD/mes"
+      },
+      "accommodation": {
+        "sharedAccommodation": "200-400 USD/mes",
+        "privateAccommodation": "400-800 USD/mes",
+        "servicedApartment": "500-1000 USD/mes",
+        "studentHousing": "150-300 USD/mes"
+      },
+      "transportation": {
+        "publicTransport": "Sistema de autobuses y mototaxis",
+        "taxi": "Muy económico y disponible",
+        "motorbike": "Opcional, 50-100 USD/mes",
+        "domesticFlight": "Vuelos domésticos económicos"
+      },
+      "climate": {
+        "description": "Clima tropical con estaciones marcadas",
+        "temperature": "20-35°C promedio anual",
+        "rainfall": "Lluvias abundantes de mayo a octubre",
+        "seasons": "Estación seca (noviembre-abril) y lluviosa (mayo-octubre)"
+      },
+      "culture": {
+        "language": "Vietnamita (oficial) e Inglés (ampliamente hablado)",
+        "religion": "Budismo, Taoísmo, Confucianismo",
+        "traditions": "Tradiciones familiares, festivales tradicionales, arte vietnamita",
+        "festivals": "Tet (Año Nuevo), Festival de la Luna, Festival de la Flor"
+      },
+      "education": {
+        "universities": "Universidades locales e internacionales",
+        "languageSchools": "Cursos de vietnamita e inglés disponibles",
+        "quality": "Educación de calidad con opciones internacionales",
+        "costs": "Muy accesible comparado con otros países"
+      },
+      "workOpportunities": {
+        "fullTime": "Posiciones en turismo, enseñanza y tecnología",
+        "sectors": "Turismo, enseñanza de inglés, tecnología, exportación",
+        "minimumWage": "Salario competitivo para extranjeros",
+        "networking": "Excelentes oportunidades de networking regional"
+      },
+      "visaInfo": {
+        "type": "Visa de Trabajo",
+        "duration": "Hasta 1 año (renovable)",
+        "requirements": "Contrato de trabajo, certificados médicos, antecedentes penales",
+        "processingTime": "1-2 semanas"
+      },
+      "costOfLiving": {
+        "monthly": "500-1000 USD",
+        "accommodation": "200-500 USD/mes",
+        "food": "150-300 USD/mes",
+        "transport": "50-100 USD/mes",
+        "entertainment": "100-200 USD/mes"
+      },
+      "safety": {
+        "level": "Seguro en general",
+        "crimeRate": "Baja en áreas turísticas",
+        "emergency": "113 (policía), 115 (ambulancia)",
+        "tips": "Evitar áreas conflictivas y respetar la cultura local"
+      },
+      "attractions": [
+        "Bahía de Halong",
+        "Hoi An",
+        "Ho Chi Minh City",
+        "Hanoi",
+        "Delta del Mekong",
+        "Sapa"
+      ],
+      "events": [
+        "Tet (Año Nuevo Vietnamita)",
+        "Festival de la Luna",
+        "Festival de la Flor",
+        "Festival de Hue",
+        "Festival de la Comida"
+      ],
+      "testimonials": [
+        {
+          "name": "Luna Nguyen",
+          "content": "Vietnam me ofreció una experiencia cultural única y oportunidades de trabajo increíbles.",
+          "program": "Work and Study",
+          "rating": 5
+        },
+        {
+          "name": "Carlos Mendoza",
+          "content": "Enseñar inglés en Vietnam fue una experiencia enriquecedora. La cultura es fascinante.",
+          "program": "Internship",
+          "rating": 5
+        }
+      ],
+      "faq": [
+        {
+          "question": "¿Necesito visa para trabajar en Vietnam?",
+          "answer": "Sí, necesitas una visa de trabajo que generalmente gestiona tu empleador. Te ayudamos con todo el proceso."
+        },
+        {
+          "question": "¿Puedo trabajar en Vietnam sin experiencia previa?",
+          "answer": "Se requiere experiencia previa en turismo o enseñanza, pero también ofrecemos programas de formación."
+        },
+        {
+          "question": "¿Qué nivel de inglés necesito?",
+          "answer": "Recomendamos nivel B1 o superior, ya que el inglés es ampliamente hablado en el sector turístico."
+        },
+        {
+          "question": "¿Es caro vivir en Vietnam?",
+          "answer": "Vietnam tiene uno de los costos de vida más bajos del sudeste asiático, muy accesible para extranjeros."
+        }
+      ],
+      "seoTitle": "Trabaja y Estudia en Vietnam - Programas Internacionales",
+      "seoDescription": "Descubre las mejores oportunidades de trabajo y estudio en Vietnam. Cultura milenaria con costo de vida bajo.",
+      "seoKeywords": [
+        "Vietnam",
+        "trabajar en Vietnam",
+        "estudiar en Vietnam",
+        "cultura milenaria",
+        "costo de vida bajo",
+        "visa de trabajo",
+        "sudeste asiático",
+        "gastronomía vietnamita"
+      ]
+    }
+  ]
+}

--- a/src/api/vietnam/services/vietnam.js
+++ b/src/api/vietnam/services/vietnam.js
@@ -1,0 +1,74 @@
+'use strict';
+
+/**
+ * vietnam service
+ */
+
+const { createCoreService } = require('@strapi/strapi').factories;
+
+module.exports = createCoreService('api::vietnam.vietnam', ({ strapi }) => ({
+  // Método personalizado para obtener información completa de Vietnam
+  async findCompleteInfo() {
+    const vietnam = await strapi.entityService.findMany('api::vietnam.vietnam', {
+      filters: { active: true },
+      populate: {
+        image: true,
+        gallery: true
+      }
+    });
+
+    return vietnam;
+  },
+
+  // Método para obtener estadísticas específicas
+  async findStatistics() {
+    const vietnam = await strapi.entityService.findMany('api::vietnam.vietnam', {
+      filters: { active: true }
+    });
+
+    return vietnam.map(item => ({
+      id: item.id,
+      statistics: item.statistics,
+      statisticsTitle: item.statisticsTitle
+    }));
+  },
+
+  // Método para obtener tips de viaje específicos
+  async findTravelTips() {
+    const vietnam = await strapi.entityService.findMany('api::vietnam.vietnam', {
+      filters: { active: true }
+    });
+
+    return vietnam.map(item => ({
+      id: item.id,
+      travelTips: item.travelTips,
+      travelTipsTitle: item.travelTipsTitle
+    }));
+  },
+
+  // Método para obtener características específicas
+  async findFeatures() {
+    const vietnam = await strapi.entityService.findMany('api::vietnam.vietnam', {
+      filters: { active: true }
+    });
+
+    return vietnam.map(item => ({
+      id: item.id,
+      features: item.features,
+      featuresTitle: item.featuresTitle
+    }));
+  },
+
+  // Método para obtener información de programas
+  async findPrograms() {
+    const vietnam = await strapi.entityService.findMany('api::vietnam.vietnam', {
+      filters: { active: true }
+    });
+
+    return vietnam.map(item => ({
+      id: item.id,
+      programs: item.programs,
+      requirements: item.requirements
+    }));
+  }
+}));

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -788,6 +788,1593 @@ export interface PluginI18NLocale extends Schema.CollectionType {
   };
 }
 
+export interface ApiAbuDhabiAbuDhabi extends Schema.CollectionType {
+  collectionName: 'abu_dhabis';
+  info: {
+    singularName: 'abu-dhabi';
+    pluralName: 'abu-dhabis';
+    displayName: 'Abu Dhabi';
+    description: 'Informaci\u00F3n detallada sobre Abu Dhabi como destino de estudio y trabajo';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    title: Attribute.String &
+      Attribute.Required &
+      Attribute.SetMinMaxLength<{
+        maxLength: 255;
+      }> &
+      Attribute.DefaultTo<'Abu Dhabi'>;
+    slug: Attribute.UID<'api::abu-dhabi.abu-dhabi', 'title'> &
+      Attribute.Required;
+    description: Attribute.RichText & Attribute.Required;
+    shortDescription: Attribute.Text &
+      Attribute.SetMinMaxLength<{
+        maxLength: 500;
+      }>;
+    image: Attribute.Media & Attribute.Required;
+    gallery: Attribute.Media;
+    whyChooseTitle: Attribute.String &
+      Attribute.DefaultTo<'\u00BFPor qu\u00E9 elegir Abu Dhabi?'>;
+    whyChooseItems: Attribute.JSON;
+    hospitalityTitle: Attribute.String &
+      Attribute.DefaultTo<'Capital Cultural'>;
+    hospitalityDescription: Attribute.String &
+      Attribute.DefaultTo<'Centro cultural y pol\u00EDtico de los Emiratos \u00C1rabes Unidos'>;
+    hospitalityIcon: Attribute.String &
+      Attribute.DefaultTo<'\uD83C\uDFDB\uFE0F'>;
+    educationTitle: Attribute.String &
+      Attribute.DefaultTo<'Educaci\u00F3n de Excelencia'>;
+    educationDescription: Attribute.String &
+      Attribute.DefaultTo<'Universidades internacionales y centros de investigaci\u00F3n'>;
+    educationIcon: Attribute.String & Attribute.DefaultTo<'\uD83C\uDF93'>;
+    cultureTitle: Attribute.String &
+      Attribute.DefaultTo<'Tradici\u00F3n \u00C1rabe'>;
+    cultureDescription: Attribute.String &
+      Attribute.DefaultTo<'Inmersi\u00F3n en la rica cultura \u00E1rabe e isl\u00E1mica'>;
+    cultureIcon: Attribute.String & Attribute.DefaultTo<'\uD83D\uDD4C'>;
+    languageTitle: Attribute.String &
+      Attribute.DefaultTo<'Idiomas M\u00FAltiples'>;
+    languageDescription: Attribute.String &
+      Attribute.DefaultTo<'Aprende \u00E1rabe e ingl\u00E9s en un entorno multicultural'>;
+    languageIcon: Attribute.String & Attribute.DefaultTo<'\uD83D\uDDE3\uFE0F'>;
+    qualityTitle: Attribute.String & Attribute.DefaultTo<'Calidad de Vida'>;
+    qualityDescription: Attribute.String &
+      Attribute.DefaultTo<'Infraestructura moderna y servicios de primera clase'>;
+    qualityIcon: Attribute.String & Attribute.DefaultTo<'\uD83C\uDFD9\uFE0F'>;
+    opportunitiesTitle: Attribute.String &
+      Attribute.DefaultTo<'Oportunidades Profesionales'>;
+    opportunitiesDescription: Attribute.String &
+      Attribute.DefaultTo<'Carrera en empresas multinacionales y sector p\u00FAblico'>;
+    opportunitiesIcon: Attribute.String & Attribute.DefaultTo<'\uD83D\uDCBC'>;
+    statisticsTitle: Attribute.String &
+      Attribute.DefaultTo<'Abu Dhabi en n\u00FAmeros'>;
+    statistics: Attribute.JSON;
+    featuresTitle: Attribute.String &
+      Attribute.DefaultTo<'Caracter\u00EDsticas de Abu Dhabi'>;
+    features: Attribute.JSON;
+    travelTipsTitle: Attribute.String &
+      Attribute.DefaultTo<'Tips de viaje para Abu Dhabi'>;
+    travelTips: Attribute.JSON;
+    programs: Attribute.JSON;
+    requirements: Attribute.JSON;
+    overview: Attribute.JSON;
+    highlights: Attribute.JSON;
+    pricing: Attribute.JSON;
+    accommodation: Attribute.JSON;
+    transportation: Attribute.JSON;
+    climate: Attribute.JSON;
+    culture: Attribute.JSON;
+    education: Attribute.JSON;
+    workOpportunities: Attribute.JSON;
+    visaInfo: Attribute.JSON;
+    costOfLiving: Attribute.JSON;
+    safety: Attribute.JSON;
+    attractions: Attribute.JSON;
+    events: Attribute.JSON;
+    testimonials: Attribute.JSON;
+    faq: Attribute.JSON;
+    seoTitle: Attribute.String;
+    seoDescription: Attribute.Text;
+    seoKeywords: Attribute.JSON;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    publishedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<
+      'api::abu-dhabi.abu-dhabi',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<
+      'api::abu-dhabi.abu-dhabi',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+  };
+}
+
+export interface ApiAustraliaAustralia extends Schema.CollectionType {
+  collectionName: 'australias';
+  info: {
+    singularName: 'australia';
+    pluralName: 'australias';
+    displayName: 'Australia';
+    description: 'Informaci\u00F3n detallada sobre Australia como destino de estudio y trabajo';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    title: Attribute.String &
+      Attribute.Required &
+      Attribute.SetMinMaxLength<{
+        maxLength: 255;
+      }> &
+      Attribute.DefaultTo<'Australia'>;
+    slug: Attribute.UID<'api::australia.australia', 'title'> &
+      Attribute.Required;
+    description: Attribute.RichText & Attribute.Required;
+    shortDescription: Attribute.Text &
+      Attribute.SetMinMaxLength<{
+        maxLength: 500;
+      }>;
+    image: Attribute.Media & Attribute.Required;
+    gallery: Attribute.Media;
+    whyChooseTitle: Attribute.String &
+      Attribute.DefaultTo<'\u00BFPor qu\u00E9 elegir Australia?'>;
+    whyChooseItems: Attribute.JSON;
+    hospitalityTitle: Attribute.String &
+      Attribute.DefaultTo<'Educaci\u00F3n de Clase Mundial'>;
+    hospitalityDescription: Attribute.String &
+      Attribute.DefaultTo<'Universidades de prestigio internacional'>;
+    hospitalityIcon: Attribute.String & Attribute.DefaultTo<'\uD83C\uDF93'>;
+    educationTitle: Attribute.String & Attribute.DefaultTo<'Calidad de Vida'>;
+    educationDescription: Attribute.String &
+      Attribute.DefaultTo<'Uno de los mejores pa\u00EDses para vivir en el mundo'>;
+    educationIcon: Attribute.String & Attribute.DefaultTo<'\uD83C\uDFE0'>;
+    cultureTitle: Attribute.String & Attribute.DefaultTo<'Cultura \u00DAnica'>;
+    cultureDescription: Attribute.String &
+      Attribute.DefaultTo<'Mezcla \u00FAnica de culturas europeas e ind\u00EDgenas'>;
+    cultureIcon: Attribute.String & Attribute.DefaultTo<'\uD83C\uDF0F'>;
+    languageTitle: Attribute.String & Attribute.DefaultTo<'Idioma Ingl\u00E9s'>;
+    languageDescription: Attribute.String &
+      Attribute.DefaultTo<'Ingl\u00E9s como idioma oficial en un entorno multicultural'>;
+    languageIcon: Attribute.String & Attribute.DefaultTo<'\uD83D\uDDE3\uFE0F'>;
+    qualityTitle: Attribute.String &
+      Attribute.DefaultTo<'Naturaleza \u00DAnica'>;
+    qualityDescription: Attribute.String &
+      Attribute.DefaultTo<'Fauna y flora \u00FAnicas en el mundo'>;
+    qualityIcon: Attribute.String & Attribute.DefaultTo<'\uD83E\uDD98'>;
+    opportunitiesTitle: Attribute.String &
+      Attribute.DefaultTo<'Oportunidades Profesionales'>;
+    opportunitiesDescription: Attribute.String &
+      Attribute.DefaultTo<'Carrera en empresas multinacionales y startups'>;
+    opportunitiesIcon: Attribute.String & Attribute.DefaultTo<'\uD83D\uDCBC'>;
+    statisticsTitle: Attribute.String &
+      Attribute.DefaultTo<'Australia en n\u00FAmeros'>;
+    statistics: Attribute.JSON;
+    featuresTitle: Attribute.String &
+      Attribute.DefaultTo<'Caracter\u00EDsticas de Australia'>;
+    features: Attribute.JSON;
+    travelTipsTitle: Attribute.String &
+      Attribute.DefaultTo<'Tips de viaje para Australia'>;
+    travelTips: Attribute.JSON;
+    programs: Attribute.JSON;
+    requirements: Attribute.JSON;
+    overview: Attribute.JSON;
+    highlights: Attribute.JSON;
+    pricing: Attribute.JSON;
+    accommodation: Attribute.JSON;
+    transportation: Attribute.JSON;
+    climate: Attribute.JSON;
+    culture: Attribute.JSON;
+    education: Attribute.JSON;
+    workOpportunities: Attribute.JSON;
+    visaInfo: Attribute.JSON;
+    costOfLiving: Attribute.JSON;
+    safety: Attribute.JSON;
+    attractions: Attribute.JSON;
+    events: Attribute.JSON;
+    testimonials: Attribute.JSON;
+    faq: Attribute.JSON;
+    seoTitle: Attribute.String;
+    seoDescription: Attribute.Text;
+    seoKeywords: Attribute.JSON;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    publishedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<
+      'api::australia.australia',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<
+      'api::australia.australia',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+  };
+}
+
+export interface ApiCanadaCanada extends Schema.CollectionType {
+  collectionName: 'canadas';
+  info: {
+    singularName: 'canada';
+    pluralName: 'canadas';
+    displayName: 'Canada';
+    description: 'Informaci\u00F3n detallada sobre Canad\u00E1 como destino de estudio y trabajo';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    title: Attribute.String &
+      Attribute.Required &
+      Attribute.SetMinMaxLength<{
+        maxLength: 255;
+      }> &
+      Attribute.DefaultTo<'Canada'>;
+    slug: Attribute.UID<'api::canada.canada', 'title'> & Attribute.Required;
+    description: Attribute.RichText & Attribute.Required;
+    shortDescription: Attribute.Text &
+      Attribute.SetMinMaxLength<{
+        maxLength: 500;
+      }>;
+    image: Attribute.Media & Attribute.Required;
+    gallery: Attribute.Media;
+    whyChooseTitle: Attribute.String &
+      Attribute.DefaultTo<'\u00BFPor qu\u00E9 elegir Canad\u00E1?'>;
+    whyChooseItems: Attribute.JSON;
+    hospitalityTitle: Attribute.String &
+      Attribute.DefaultTo<'Educaci\u00F3n de Excelencia'>;
+    hospitalityDescription: Attribute.String &
+      Attribute.DefaultTo<'Universidades de prestigio mundial con costos accesibles'>;
+    hospitalityIcon: Attribute.String & Attribute.DefaultTo<'\uD83C\uDF93'>;
+    educationTitle: Attribute.String & Attribute.DefaultTo<'Multiculturalismo'>;
+    educationDescription: Attribute.String &
+      Attribute.DefaultTo<'Pa\u00EDs que celebra la diversidad cultural'>;
+    educationIcon: Attribute.String & Attribute.DefaultTo<'\uD83C\uDF0D'>;
+    cultureTitle: Attribute.String & Attribute.DefaultTo<'Calidad de Vida'>;
+    cultureDescription: Attribute.String &
+      Attribute.DefaultTo<'Uno de los mejores pa\u00EDses para vivir en el mundo'>;
+    cultureIcon: Attribute.String & Attribute.DefaultTo<'\uD83C\uDFE0'>;
+    languageTitle: Attribute.String & Attribute.DefaultTo<'Idiomas Oficiales'>;
+    languageDescription: Attribute.String &
+      Attribute.DefaultTo<'Ingl\u00E9s y franc\u00E9s como idiomas oficiales'>;
+    languageIcon: Attribute.String & Attribute.DefaultTo<'\uD83D\uDDE3\uFE0F'>;
+    qualityTitle: Attribute.String &
+      Attribute.DefaultTo<'Naturaleza \u00DAnica'>;
+    qualityDescription: Attribute.String &
+      Attribute.DefaultTo<'Desde monta\u00F1as hasta oc\u00E9anos, naturaleza espectacular'>;
+    qualityIcon: Attribute.String & Attribute.DefaultTo<'\uD83C\uDFD4\uFE0F'>;
+    opportunitiesTitle: Attribute.String &
+      Attribute.DefaultTo<'Oportunidades Profesionales'>;
+    opportunitiesDescription: Attribute.String &
+      Attribute.DefaultTo<'Carrera en empresas multinacionales y startups'>;
+    opportunitiesIcon: Attribute.String & Attribute.DefaultTo<'\uD83D\uDCBC'>;
+    statisticsTitle: Attribute.String &
+      Attribute.DefaultTo<'Canad\u00E1 en n\u00FAmeros'>;
+    statistics: Attribute.JSON;
+    featuresTitle: Attribute.String &
+      Attribute.DefaultTo<'Caracter\u00EDsticas de Canad\u00E1'>;
+    features: Attribute.JSON;
+    travelTipsTitle: Attribute.String &
+      Attribute.DefaultTo<'Tips de viaje para Canad\u00E1'>;
+    travelTips: Attribute.JSON;
+    programs: Attribute.JSON;
+    requirements: Attribute.JSON;
+    overview: Attribute.JSON;
+    highlights: Attribute.JSON;
+    pricing: Attribute.JSON;
+    accommodation: Attribute.JSON;
+    transportation: Attribute.JSON;
+    climate: Attribute.JSON;
+    culture: Attribute.JSON;
+    education: Attribute.JSON;
+    workOpportunities: Attribute.JSON;
+    visaInfo: Attribute.JSON;
+    costOfLiving: Attribute.JSON;
+    safety: Attribute.JSON;
+    attractions: Attribute.JSON;
+    events: Attribute.JSON;
+    testimonials: Attribute.JSON;
+    faq: Attribute.JSON;
+    seoTitle: Attribute.String;
+    seoDescription: Attribute.Text;
+    seoKeywords: Attribute.JSON;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    publishedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<
+      'api::canada.canada',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<
+      'api::canada.canada',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+  };
+}
+
+export interface ApiDubaiDubai extends Schema.CollectionType {
+  collectionName: 'dubais';
+  info: {
+    singularName: 'dubai';
+    pluralName: 'dubais';
+    displayName: 'Dubai';
+    description: 'Informaci\u00F3n detallada sobre Dubai como destino de estudio y trabajo';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    title: Attribute.String &
+      Attribute.Required &
+      Attribute.SetMinMaxLength<{
+        maxLength: 255;
+      }> &
+      Attribute.DefaultTo<'Dubai'>;
+    slug: Attribute.UID<'api::dubai.dubai', 'title'> & Attribute.Required;
+    description: Attribute.RichText & Attribute.Required;
+    shortDescription: Attribute.Text &
+      Attribute.SetMinMaxLength<{
+        maxLength: 500;
+      }>;
+    image: Attribute.Media & Attribute.Required;
+    gallery: Attribute.Media;
+    whyChooseTitle: Attribute.String &
+      Attribute.DefaultTo<'\u00BFPor qu\u00E9 elegir Dubai?'>;
+    whyChooseItems: Attribute.JSON;
+    hospitalityTitle: Attribute.String &
+      Attribute.DefaultTo<'Centro Comercial Global'>;
+    hospitalityDescription: Attribute.String &
+      Attribute.DefaultTo<'Hub de negocios y comercio en el Medio Oriente'>;
+    hospitalityIcon: Attribute.String & Attribute.DefaultTo<'\uD83C\uDFE2'>;
+    educationTitle: Attribute.String &
+      Attribute.DefaultTo<'Educaci\u00F3n Internacional'>;
+    educationDescription: Attribute.String &
+      Attribute.DefaultTo<'Universidades de prestigio mundial'>;
+    educationIcon: Attribute.String & Attribute.DefaultTo<'\uD83C\uDF93'>;
+    cultureTitle: Attribute.String &
+      Attribute.DefaultTo<'Fusi\u00F3n Cultural'>;
+    cultureDescription: Attribute.String &
+      Attribute.DefaultTo<'Mezcla \u00FAnica de tradici\u00F3n \u00E1rabe y modernidad'>;
+    cultureIcon: Attribute.String & Attribute.DefaultTo<'\uD83C\uDF0F'>;
+    languageTitle: Attribute.String &
+      Attribute.DefaultTo<'Idiomas M\u00FAltiples'>;
+    languageDescription: Attribute.String &
+      Attribute.DefaultTo<'\u00C1rabe, ingl\u00E9s y m\u00E1s de 200 idiomas'>;
+    languageIcon: Attribute.String & Attribute.DefaultTo<'\uD83D\uDDE3\uFE0F'>;
+    qualityTitle: Attribute.String & Attribute.DefaultTo<'Lujo y Modernidad'>;
+    qualityDescription: Attribute.String &
+      Attribute.DefaultTo<'Infraestructura de clase mundial'>;
+    qualityIcon: Attribute.String & Attribute.DefaultTo<'\uD83C\uDFD9\uFE0F'>;
+    opportunitiesTitle: Attribute.String &
+      Attribute.DefaultTo<'Oportunidades Profesionales'>;
+    opportunitiesDescription: Attribute.String &
+      Attribute.DefaultTo<'Carrera en empresas multinacionales y startups'>;
+    opportunitiesIcon: Attribute.String & Attribute.DefaultTo<'\uD83D\uDCBC'>;
+    statisticsTitle: Attribute.String &
+      Attribute.DefaultTo<'Dubai en n\u00FAmeros'>;
+    statistics: Attribute.JSON;
+    featuresTitle: Attribute.String &
+      Attribute.DefaultTo<'Caracter\u00EDsticas de Dubai'>;
+    features: Attribute.JSON;
+    travelTipsTitle: Attribute.String &
+      Attribute.DefaultTo<'Tips de viaje para Dubai'>;
+    travelTips: Attribute.JSON;
+    programs: Attribute.JSON;
+    requirements: Attribute.JSON;
+    overview: Attribute.JSON;
+    highlights: Attribute.JSON;
+    pricing: Attribute.JSON;
+    accommodation: Attribute.JSON;
+    transportation: Attribute.JSON;
+    climate: Attribute.JSON;
+    culture: Attribute.JSON;
+    education: Attribute.JSON;
+    workOpportunities: Attribute.JSON;
+    visaInfo: Attribute.JSON;
+    costOfLiving: Attribute.JSON;
+    safety: Attribute.JSON;
+    attractions: Attribute.JSON;
+    events: Attribute.JSON;
+    testimonials: Attribute.JSON;
+    faq: Attribute.JSON;
+    seoTitle: Attribute.String;
+    seoDescription: Attribute.Text;
+    seoKeywords: Attribute.JSON;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    publishedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<
+      'api::dubai.dubai',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<
+      'api::dubai.dubai',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+  };
+}
+
+export interface ApiHongKongHongKong extends Schema.CollectionType {
+  collectionName: 'hong_kongs';
+  info: {
+    singularName: 'hong-kong';
+    pluralName: 'hong-kongs';
+    displayName: 'Hong Kong';
+    description: 'Informaci\u00F3n detallada sobre Hong Kong como destino de estudio y trabajo';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    title: Attribute.String &
+      Attribute.Required &
+      Attribute.SetMinMaxLength<{
+        maxLength: 255;
+      }> &
+      Attribute.DefaultTo<'Hong Kong'>;
+    slug: Attribute.UID<'api::hong-kong.hong-kong', 'title'> &
+      Attribute.Required;
+    description: Attribute.RichText & Attribute.Required;
+    shortDescription: Attribute.Text &
+      Attribute.SetMinMaxLength<{
+        maxLength: 500;
+      }>;
+    image: Attribute.Media & Attribute.Required;
+    gallery: Attribute.Media;
+    whyChooseTitle: Attribute.String &
+      Attribute.DefaultTo<'\u00BFPor qu\u00E9 elegir Hong Kong?'>;
+    whyChooseItems: Attribute.JSON;
+    hospitalityTitle: Attribute.String &
+      Attribute.DefaultTo<'Centro Financiero Global'>;
+    hospitalityDescription: Attribute.String &
+      Attribute.DefaultTo<'Oportunidades en el coraz\u00F3n financiero de Asia'>;
+    hospitalityIcon: Attribute.String & Attribute.DefaultTo<'\uD83C\uDFE6'>;
+    educationTitle: Attribute.String &
+      Attribute.DefaultTo<'Educaci\u00F3n de Clase Mundial'>;
+    educationDescription: Attribute.String &
+      Attribute.DefaultTo<'Universidades de prestigio internacional'>;
+    educationIcon: Attribute.String & Attribute.DefaultTo<'\uD83C\uDF93'>;
+    cultureTitle: Attribute.String &
+      Attribute.DefaultTo<'Fusi\u00F3n Cultural'>;
+    cultureDescription: Attribute.String &
+      Attribute.DefaultTo<'Mezcla \u00FAnica de tradici\u00F3n china y modernidad occidental'>;
+    cultureIcon: Attribute.String & Attribute.DefaultTo<'\uD83C\uDF0F'>;
+    languageTitle: Attribute.String &
+      Attribute.DefaultTo<'Idiomas M\u00FAltiples'>;
+    languageDescription: Attribute.String &
+      Attribute.DefaultTo<'Ingl\u00E9s, canton\u00E9s y mandar\u00EDn en un solo lugar'>;
+    languageIcon: Attribute.String & Attribute.DefaultTo<'\uD83D\uDDE3\uFE0F'>;
+    qualityTitle: Attribute.String & Attribute.DefaultTo<'Calidad de Vida'>;
+    qualityDescription: Attribute.String &
+      Attribute.DefaultTo<'Infraestructura moderna y servicios de primera'>;
+    qualityIcon: Attribute.String & Attribute.DefaultTo<'\uD83C\uDFD9\uFE0F'>;
+    opportunitiesTitle: Attribute.String &
+      Attribute.DefaultTo<'Oportunidades Profesionales'>;
+    opportunitiesDescription: Attribute.String &
+      Attribute.DefaultTo<'Carrera en empresas multinacionales y startups'>;
+    opportunitiesIcon: Attribute.String & Attribute.DefaultTo<'\uD83D\uDCBC'>;
+    statisticsTitle: Attribute.String &
+      Attribute.DefaultTo<'Hong Kong en n\u00FAmeros'>;
+    statistics: Attribute.JSON;
+    featuresTitle: Attribute.String &
+      Attribute.DefaultTo<'Caracter\u00EDsticas de Hong Kong'>;
+    features: Attribute.JSON;
+    travelTipsTitle: Attribute.String &
+      Attribute.DefaultTo<'Tips de viaje para Hong Kong'>;
+    travelTips: Attribute.JSON;
+    programs: Attribute.JSON;
+    requirements: Attribute.JSON;
+    overview: Attribute.JSON;
+    highlights: Attribute.JSON;
+    pricing: Attribute.JSON;
+    accommodation: Attribute.JSON;
+    transportation: Attribute.JSON;
+    climate: Attribute.JSON;
+    culture: Attribute.JSON;
+    education: Attribute.JSON;
+    workOpportunities: Attribute.JSON;
+    visaInfo: Attribute.JSON;
+    costOfLiving: Attribute.JSON;
+    safety: Attribute.JSON;
+    attractions: Attribute.JSON;
+    events: Attribute.JSON;
+    testimonials: Attribute.JSON;
+    faq: Attribute.JSON;
+    seoTitle: Attribute.String;
+    seoDescription: Attribute.Text;
+    seoKeywords: Attribute.JSON;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    publishedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<
+      'api::hong-kong.hong-kong',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<
+      'api::hong-kong.hong-kong',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+  };
+}
+
+export interface ApiIrelandIreland extends Schema.CollectionType {
+  collectionName: 'irelands';
+  info: {
+    singularName: 'ireland';
+    pluralName: 'irelands';
+    displayName: 'Ireland';
+    description: 'Informaci\u00F3n detallada sobre Irlanda como destino de estudio y trabajo';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    title: Attribute.String &
+      Attribute.Required &
+      Attribute.SetMinMaxLength<{
+        maxLength: 255;
+      }> &
+      Attribute.DefaultTo<'Irlanda'>;
+    slug: Attribute.UID<'api::ireland.ireland', 'title'> & Attribute.Required;
+    description: Attribute.RichText & Attribute.Required;
+    shortDescription: Attribute.Text &
+      Attribute.SetMinMaxLength<{
+        maxLength: 500;
+      }>;
+    image: Attribute.Media & Attribute.Required;
+    gallery: Attribute.Media;
+    whyChooseTitle: Attribute.String &
+      Attribute.DefaultTo<'\u00BFPor qu\u00E9 elegir Irlanda?'>;
+    whyChooseItems: Attribute.JSON;
+    hospitalityTitle: Attribute.String &
+      Attribute.DefaultTo<'Hospitalidad Irlandesa'>;
+    hospitalityDescription: Attribute.String &
+      Attribute.DefaultTo<'Experiencia en pubs tradicionales y hoteles boutique'>;
+    hospitalityIcon: Attribute.String & Attribute.DefaultTo<'\uD83C\uDF7A'>;
+    educationTitle: Attribute.String &
+      Attribute.DefaultTo<'Educaci\u00F3n Internacional'>;
+    educationDescription: Attribute.String &
+      Attribute.DefaultTo<'Estudios en instituciones reconocidas mundialmente'>;
+    educationIcon: Attribute.String & Attribute.DefaultTo<'\uD83C\uDF93'>;
+    cultureTitle: Attribute.String & Attribute.DefaultTo<'Cultura \u00DAnica'>;
+    cultureDescription: Attribute.String &
+      Attribute.DefaultTo<'Inmersi\u00F3n en la rica herencia celta y moderna'>;
+    cultureIcon: Attribute.String & Attribute.DefaultTo<'\uD83C\uDF0D'>;
+    languageTitle: Attribute.String &
+      Attribute.DefaultTo<'Ingl\u00E9s como Idioma'>;
+    languageDescription: Attribute.String &
+      Attribute.DefaultTo<'Mejora tu ingl\u00E9s en un entorno nativo'>;
+    languageIcon: Attribute.String & Attribute.DefaultTo<'\uD83D\uDCAC'>;
+    qualityTitle: Attribute.String & Attribute.DefaultTo<'Calidad de Vida'>;
+    qualityDescription: Attribute.String &
+      Attribute.DefaultTo<'Pa\u00EDs con alto nivel de vida y seguridad'>;
+    qualityIcon: Attribute.String & Attribute.DefaultTo<'\uD83C\uDFE0'>;
+    opportunitiesTitle: Attribute.String &
+      Attribute.DefaultTo<'Oportunidades Laborales'>;
+    opportunitiesDescription: Attribute.String &
+      Attribute.DefaultTo<'Acceso al mercado laboral europeo'>;
+    opportunitiesIcon: Attribute.String & Attribute.DefaultTo<'\uD83D\uDCBC'>;
+    statisticsTitle: Attribute.String &
+      Attribute.DefaultTo<'Irlanda en n\u00FAmeros'>;
+    statistics: Attribute.JSON;
+    featuresTitle: Attribute.String &
+      Attribute.DefaultTo<'Caracter\u00EDsticas de Irlanda'>;
+    features: Attribute.JSON;
+    travelTipsTitle: Attribute.String &
+      Attribute.DefaultTo<'Tips de viaje para Irlanda'>;
+    travelTips: Attribute.JSON;
+    programs: Attribute.JSON;
+    requirements: Attribute.JSON;
+    overview: Attribute.JSON;
+    highlights: Attribute.JSON;
+    pricing: Attribute.JSON;
+    accommodation: Attribute.JSON;
+    transportation: Attribute.JSON;
+    climate: Attribute.JSON;
+    culture: Attribute.JSON;
+    education: Attribute.JSON;
+    workOpportunities: Attribute.JSON;
+    visaInfo: Attribute.JSON;
+    costOfLiving: Attribute.JSON;
+    safety: Attribute.JSON;
+    attractions: Attribute.JSON;
+    events: Attribute.JSON;
+    testimonials: Attribute.JSON;
+    faq: Attribute.JSON;
+    seoTitle: Attribute.String;
+    seoDescription: Attribute.Text;
+    seoKeywords: Attribute.JSON;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    publishedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<
+      'api::ireland.ireland',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<
+      'api::ireland.ireland',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+  };
+}
+
+export interface ApiMaldiveMaldive extends Schema.CollectionType {
+  collectionName: 'maldives';
+  info: {
+    singularName: 'maldive';
+    pluralName: 'maldives';
+    displayName: 'Maldives';
+    description: 'Informaci\u00F3n detallada sobre Maldivas como destino de estudio y trabajo';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    title: Attribute.String &
+      Attribute.Required &
+      Attribute.SetMinMaxLength<{
+        maxLength: 255;
+      }> &
+      Attribute.DefaultTo<'Maldives'>;
+    slug: Attribute.UID<'api::maldive.maldive', 'title'> & Attribute.Required;
+    description: Attribute.RichText & Attribute.Required;
+    shortDescription: Attribute.Text &
+      Attribute.SetMinMaxLength<{
+        maxLength: 500;
+      }>;
+    image: Attribute.Media & Attribute.Required;
+    gallery: Attribute.Media;
+    whyChooseTitle: Attribute.String &
+      Attribute.DefaultTo<'\u00BFPor qu\u00E9 elegir Maldivas?'>;
+    whyChooseItems: Attribute.JSON;
+    hospitalityTitle: Attribute.String & Attribute.DefaultTo<'Turismo de Lujo'>;
+    hospitalityDescription: Attribute.String &
+      Attribute.DefaultTo<'Experiencia en resorts de clase mundial'>;
+    hospitalityIcon: Attribute.String &
+      Attribute.DefaultTo<'\uD83C\uDFD6\uFE0F'>;
+    educationTitle: Attribute.String &
+      Attribute.DefaultTo<'Conservaci\u00F3n Marina'>;
+    educationDescription: Attribute.String &
+      Attribute.DefaultTo<'Aprendizaje sobre ecosistemas marinos \u00FAnicos'>;
+    educationIcon: Attribute.String & Attribute.DefaultTo<'\uD83D\uDC20'>;
+    cultureTitle: Attribute.String &
+      Attribute.DefaultTo<'Cultura Isl\u00E1mica'>;
+    cultureDescription: Attribute.String &
+      Attribute.DefaultTo<'Inmersi\u00F3n en la cultura isl\u00E1mica del oc\u00E9ano \u00CDndico'>;
+    cultureIcon: Attribute.String & Attribute.DefaultTo<'\uD83D\uDD4C'>;
+    languageTitle: Attribute.String & Attribute.DefaultTo<'Idiomas Locales'>;
+    languageDescription: Attribute.String &
+      Attribute.DefaultTo<'Aprende dhivehi e ingl\u00E9s en un para\u00EDso tropical'>;
+    languageIcon: Attribute.String & Attribute.DefaultTo<'\uD83D\uDDE3\uFE0F'>;
+    qualityTitle: Attribute.String &
+      Attribute.DefaultTo<'Para\u00EDso Natural'>;
+    qualityDescription: Attribute.String &
+      Attribute.DefaultTo<'Playas v\u00EDrgenes y arrecifes de coral \u00FAnicos'>;
+    qualityIcon: Attribute.String & Attribute.DefaultTo<'\uD83C\uDF0A'>;
+    opportunitiesTitle: Attribute.String &
+      Attribute.DefaultTo<'Hospitalidad Premium'>;
+    opportunitiesDescription: Attribute.String &
+      Attribute.DefaultTo<'Oportunidades en el sector tur\u00EDstico de lujo'>;
+    opportunitiesIcon: Attribute.String & Attribute.DefaultTo<'\u2B50'>;
+    statisticsTitle: Attribute.String &
+      Attribute.DefaultTo<'Maldivas en n\u00FAmeros'>;
+    statistics: Attribute.JSON;
+    featuresTitle: Attribute.String &
+      Attribute.DefaultTo<'Caracter\u00EDsticas de Maldivas'>;
+    features: Attribute.JSON;
+    travelTipsTitle: Attribute.String &
+      Attribute.DefaultTo<'Tips de viaje para Maldivas'>;
+    travelTips: Attribute.JSON;
+    programs: Attribute.JSON;
+    requirements: Attribute.JSON;
+    overview: Attribute.JSON;
+    highlights: Attribute.JSON;
+    pricing: Attribute.JSON;
+    accommodation: Attribute.JSON;
+    transportation: Attribute.JSON;
+    climate: Attribute.JSON;
+    culture: Attribute.JSON;
+    education: Attribute.JSON;
+    workOpportunities: Attribute.JSON;
+    visaInfo: Attribute.JSON;
+    costOfLiving: Attribute.JSON;
+    safety: Attribute.JSON;
+    attractions: Attribute.JSON;
+    events: Attribute.JSON;
+    testimonials: Attribute.JSON;
+    faq: Attribute.JSON;
+    seoTitle: Attribute.String;
+    seoDescription: Attribute.Text;
+    seoKeywords: Attribute.JSON;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    publishedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<
+      'api::maldive.maldive',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<
+      'api::maldive.maldive',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+  };
+}
+
+export interface ApiMaltaMalta extends Schema.CollectionType {
+  collectionName: 'maltas';
+  info: {
+    singularName: 'malta';
+    pluralName: 'maltas';
+    displayName: 'Malta';
+    description: 'Informaci\u00F3n detallada sobre Malta como destino de estudio y trabajo';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    title: Attribute.String &
+      Attribute.Required &
+      Attribute.SetMinMaxLength<{
+        maxLength: 255;
+      }> &
+      Attribute.DefaultTo<'Malta'>;
+    slug: Attribute.UID<'api::malta.malta', 'title'> & Attribute.Required;
+    description: Attribute.RichText & Attribute.Required;
+    shortDescription: Attribute.Text &
+      Attribute.SetMinMaxLength<{
+        maxLength: 500;
+      }>;
+    image: Attribute.Media & Attribute.Required;
+    gallery: Attribute.Media;
+    whyChooseTitle: Attribute.String &
+      Attribute.DefaultTo<'\u00BFPor qu\u00E9 elegir Malta?'>;
+    whyChooseItems: Attribute.JSON;
+    hospitalityTitle: Attribute.String &
+      Attribute.DefaultTo<'Historia Mediterr\u00E1nea'>;
+    hospitalityDescription: Attribute.String &
+      Attribute.DefaultTo<'Isla con 7,000 a\u00F1os de historia y cultura'>;
+    hospitalityIcon: Attribute.String &
+      Attribute.DefaultTo<'\uD83C\uDFDB\uFE0F'>;
+    educationTitle: Attribute.String &
+      Attribute.DefaultTo<'Educaci\u00F3n en Ingl\u00E9s'>;
+    educationDescription: Attribute.String &
+      Attribute.DefaultTo<'Educaci\u00F3n de calidad en ingl\u00E9s como idioma oficial'>;
+    educationIcon: Attribute.String & Attribute.DefaultTo<'\uD83C\uDF93'>;
+    cultureTitle: Attribute.String &
+      Attribute.DefaultTo<'Cultura Mediterr\u00E1nea'>;
+    cultureDescription: Attribute.String &
+      Attribute.DefaultTo<'Mezcla \u00FAnica de culturas europeas y \u00E1rabes'>;
+    cultureIcon: Attribute.String & Attribute.DefaultTo<'\uD83C\uDF0A'>;
+    languageTitle: Attribute.String &
+      Attribute.DefaultTo<'Idiomas M\u00FAltiples'>;
+    languageDescription: Attribute.String &
+      Attribute.DefaultTo<'Ingl\u00E9s, malt\u00E9s e italiano en un solo lugar'>;
+    languageIcon: Attribute.String & Attribute.DefaultTo<'\uD83D\uDDE3\uFE0F'>;
+    qualityTitle: Attribute.String & Attribute.DefaultTo<'Calidad de Vida'>;
+    qualityDescription: Attribute.String &
+      Attribute.DefaultTo<'Excelente clima y calidad de vida mediterr\u00E1nea'>;
+    qualityIcon: Attribute.String & Attribute.DefaultTo<'\u2600\uFE0F'>;
+    opportunitiesTitle: Attribute.String &
+      Attribute.DefaultTo<'Oportunidades Profesionales'>;
+    opportunitiesDescription: Attribute.String &
+      Attribute.DefaultTo<'Carrera en empresas europeas y sector tur\u00EDstico'>;
+    opportunitiesIcon: Attribute.String & Attribute.DefaultTo<'\uD83D\uDCBC'>;
+    statisticsTitle: Attribute.String &
+      Attribute.DefaultTo<'Malta en n\u00FAmeros'>;
+    statistics: Attribute.JSON;
+    featuresTitle: Attribute.String &
+      Attribute.DefaultTo<'Caracter\u00EDsticas de Malta'>;
+    features: Attribute.JSON;
+    travelTipsTitle: Attribute.String &
+      Attribute.DefaultTo<'Tips de viaje para Malta'>;
+    travelTips: Attribute.JSON;
+    programs: Attribute.JSON;
+    requirements: Attribute.JSON;
+    overview: Attribute.JSON;
+    highlights: Attribute.JSON;
+    pricing: Attribute.JSON;
+    accommodation: Attribute.JSON;
+    transportation: Attribute.JSON;
+    climate: Attribute.JSON;
+    culture: Attribute.JSON;
+    education: Attribute.JSON;
+    workOpportunities: Attribute.JSON;
+    visaInfo: Attribute.JSON;
+    costOfLiving: Attribute.JSON;
+    safety: Attribute.JSON;
+    attractions: Attribute.JSON;
+    events: Attribute.JSON;
+    testimonials: Attribute.JSON;
+    faq: Attribute.JSON;
+    seoTitle: Attribute.String;
+    seoDescription: Attribute.Text;
+    seoKeywords: Attribute.JSON;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    publishedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<
+      'api::malta.malta',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<
+      'api::malta.malta',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+  };
+}
+
+export interface ApiPraguePrague extends Schema.CollectionType {
+  collectionName: 'pragues';
+  info: {
+    singularName: 'prague';
+    pluralName: 'pragues';
+    displayName: 'Prague';
+    description: 'Informaci\u00F3n detallada sobre Praga como destino de estudio y trabajo';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    title: Attribute.String &
+      Attribute.Required &
+      Attribute.SetMinMaxLength<{
+        maxLength: 255;
+      }> &
+      Attribute.DefaultTo<'Prague'>;
+    slug: Attribute.UID<'api::prague.prague', 'title'> & Attribute.Required;
+    description: Attribute.RichText & Attribute.Required;
+    shortDescription: Attribute.Text &
+      Attribute.SetMinMaxLength<{
+        maxLength: 500;
+      }>;
+    image: Attribute.Media & Attribute.Required;
+    gallery: Attribute.Media;
+    whyChooseTitle: Attribute.String &
+      Attribute.DefaultTo<'\u00BFPor qu\u00E9 elegir Praga?'>;
+    whyChooseItems: Attribute.JSON;
+    hospitalityTitle: Attribute.String &
+      Attribute.DefaultTo<'Historia Milenaria'>;
+    hospitalityDescription: Attribute.String &
+      Attribute.DefaultTo<'Ciudad medieval perfectamente conservada'>;
+    hospitalityIcon: Attribute.String & Attribute.DefaultTo<'\uD83C\uDFF0'>;
+    educationTitle: Attribute.String &
+      Attribute.DefaultTo<'Educaci\u00F3n de Calidad'>;
+    educationDescription: Attribute.String &
+      Attribute.DefaultTo<'Universidades de prestigio con costos accesibles'>;
+    educationIcon: Attribute.String & Attribute.DefaultTo<'\uD83C\uDF93'>;
+    cultureTitle: Attribute.String & Attribute.DefaultTo<'Cultura Bohemia'>;
+    cultureDescription: Attribute.String &
+      Attribute.DefaultTo<'Arte, m\u00FAsica y literatura de clase mundial'>;
+    cultureIcon: Attribute.String & Attribute.DefaultTo<'\uD83C\uDFAD'>;
+    languageTitle: Attribute.String & Attribute.DefaultTo<'Idiomas Europeos'>;
+    languageDescription: Attribute.String &
+      Attribute.DefaultTo<'Aprende checo, ingl\u00E9s y otros idiomas europeos'>;
+    languageIcon: Attribute.String & Attribute.DefaultTo<'\uD83D\uDDE3\uFE0F'>;
+    qualityTitle: Attribute.String & Attribute.DefaultTo<'Calidad de Vida'>;
+    qualityDescription: Attribute.String &
+      Attribute.DefaultTo<'Excelente relaci\u00F3n calidad-precio en Europa'>;
+    qualityIcon: Attribute.String & Attribute.DefaultTo<'\uD83C\uDFE0'>;
+    opportunitiesTitle: Attribute.String &
+      Attribute.DefaultTo<'Oportunidades Profesionales'>;
+    opportunitiesDescription: Attribute.String &
+      Attribute.DefaultTo<'Carrera en empresas europeas y startups'>;
+    opportunitiesIcon: Attribute.String & Attribute.DefaultTo<'\uD83D\uDCBC'>;
+    statisticsTitle: Attribute.String &
+      Attribute.DefaultTo<'Praga en n\u00FAmeros'>;
+    statistics: Attribute.JSON;
+    featuresTitle: Attribute.String &
+      Attribute.DefaultTo<'Caracter\u00EDsticas de Praga'>;
+    features: Attribute.JSON;
+    travelTipsTitle: Attribute.String &
+      Attribute.DefaultTo<'Tips de viaje para Praga'>;
+    travelTips: Attribute.JSON;
+    programs: Attribute.JSON;
+    requirements: Attribute.JSON;
+    overview: Attribute.JSON;
+    highlights: Attribute.JSON;
+    pricing: Attribute.JSON;
+    accommodation: Attribute.JSON;
+    transportation: Attribute.JSON;
+    climate: Attribute.JSON;
+    culture: Attribute.JSON;
+    education: Attribute.JSON;
+    workOpportunities: Attribute.JSON;
+    visaInfo: Attribute.JSON;
+    costOfLiving: Attribute.JSON;
+    safety: Attribute.JSON;
+    attractions: Attribute.JSON;
+    events: Attribute.JSON;
+    testimonials: Attribute.JSON;
+    faq: Attribute.JSON;
+    seoTitle: Attribute.String;
+    seoDescription: Attribute.Text;
+    seoKeywords: Attribute.JSON;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    publishedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<
+      'api::prague.prague',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<
+      'api::prague.prague',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+  };
+}
+
+export interface ApiQatarQatar extends Schema.CollectionType {
+  collectionName: 'qatars';
+  info: {
+    singularName: 'qatar';
+    pluralName: 'qatars';
+    displayName: 'Qatar';
+    description: 'Informaci\u00F3n detallada sobre Qatar como destino de estudio y trabajo';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    title: Attribute.String &
+      Attribute.Required &
+      Attribute.SetMinMaxLength<{
+        maxLength: 255;
+      }> &
+      Attribute.DefaultTo<'Qatar'>;
+    slug: Attribute.UID<'api::qatar.qatar', 'title'> & Attribute.Required;
+    description: Attribute.RichText & Attribute.Required;
+    shortDescription: Attribute.Text &
+      Attribute.SetMinMaxLength<{
+        maxLength: 500;
+      }>;
+    image: Attribute.Media & Attribute.Required;
+    gallery: Attribute.Media;
+    whyChooseTitle: Attribute.String &
+      Attribute.DefaultTo<'\u00BFPor qu\u00E9 elegir Qatar?'>;
+    whyChooseItems: Attribute.JSON;
+    hospitalityTitle: Attribute.String &
+      Attribute.DefaultTo<'Hospitalidad de Lujo'>;
+    hospitalityDescription: Attribute.String &
+      Attribute.DefaultTo<'Experiencia en los hoteles m\u00E1s prestigiosos del Medio Oriente'>;
+    hospitalityIcon: Attribute.String & Attribute.DefaultTo<'\u2B50'>;
+    educationTitle: Attribute.String &
+      Attribute.DefaultTo<'Eventos Internacionales'>;
+    educationDescription: Attribute.String &
+      Attribute.DefaultTo<'Participaci\u00F3n en la organizaci\u00F3n de eventos deportivos y culturales'>;
+    educationIcon: Attribute.String & Attribute.DefaultTo<'\uD83C\uDFC6'>;
+    cultureTitle: Attribute.String &
+      Attribute.DefaultTo<'Desarrollo Profesional'>;
+    cultureDescription: Attribute.String &
+      Attribute.DefaultTo<'Formaci\u00F3n en est\u00E1ndares internacionales de servicio'>;
+    cultureIcon: Attribute.String & Attribute.DefaultTo<'\uD83D\uDCC8'>;
+    languageTitle: Attribute.String & Attribute.DefaultTo<'Paquete Completo'>;
+    languageDescription: Attribute.String &
+      Attribute.DefaultTo<'Alojamiento y transporte incluidos en la mayor\u00EDa de posiciones'>;
+    languageIcon: Attribute.String & Attribute.DefaultTo<'\uD83D\uDCE6'>;
+    qualityTitle: Attribute.String &
+      Attribute.DefaultTo<'Ambiente Multicultural'>;
+    qualityDescription: Attribute.String &
+      Attribute.DefaultTo<'Trabajo con profesionales de todo el mundo'>;
+    qualityIcon: Attribute.String & Attribute.DefaultTo<'\uD83C\uDF0D'>;
+    opportunitiesTitle: Attribute.String &
+      Attribute.DefaultTo<'Beneficios Atractivos'>;
+    opportunitiesDescription: Attribute.String &
+      Attribute.DefaultTo<'Salario libre de impuestos y bonificaciones'>;
+    opportunitiesIcon: Attribute.String & Attribute.DefaultTo<'\uD83D\uDCB0'>;
+    statisticsTitle: Attribute.String &
+      Attribute.DefaultTo<'Qatar en n\u00FAmeros'>;
+    statistics: Attribute.JSON;
+    featuresTitle: Attribute.String &
+      Attribute.DefaultTo<'Caracter\u00EDsticas de Qatar'>;
+    features: Attribute.JSON;
+    travelTipsTitle: Attribute.String &
+      Attribute.DefaultTo<'Tips de viaje para Qatar'>;
+    travelTips: Attribute.JSON;
+    programs: Attribute.JSON;
+    requirements: Attribute.JSON;
+    overview: Attribute.JSON;
+    highlights: Attribute.JSON;
+    pricing: Attribute.JSON;
+    accommodation: Attribute.JSON;
+    transportation: Attribute.JSON;
+    climate: Attribute.JSON;
+    culture: Attribute.JSON;
+    education: Attribute.JSON;
+    workOpportunities: Attribute.JSON;
+    visaInfo: Attribute.JSON;
+    costOfLiving: Attribute.JSON;
+    safety: Attribute.JSON;
+    attractions: Attribute.JSON;
+    events: Attribute.JSON;
+    testimonials: Attribute.JSON;
+    faq: Attribute.JSON;
+    seoTitle: Attribute.String;
+    seoDescription: Attribute.Text;
+    seoKeywords: Attribute.JSON;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    publishedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<
+      'api::qatar.qatar',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<
+      'api::qatar.qatar',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+  };
+}
+
+export interface ApiSpainSpain extends Schema.CollectionType {
+  collectionName: 'spains';
+  info: {
+    singularName: 'spain';
+    pluralName: 'spains';
+    displayName: 'Spain';
+    description: 'Informaci\u00F3n detallada sobre Espa\u00F1a como destino de estudio y trabajo';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    title: Attribute.String &
+      Attribute.Required &
+      Attribute.SetMinMaxLength<{
+        maxLength: 255;
+      }> &
+      Attribute.DefaultTo<'Spain'>;
+    slug: Attribute.UID<'api::spain.spain', 'title'> & Attribute.Required;
+    description: Attribute.RichText & Attribute.Required;
+    shortDescription: Attribute.Text &
+      Attribute.SetMinMaxLength<{
+        maxLength: 500;
+      }>;
+    image: Attribute.Media & Attribute.Required;
+    gallery: Attribute.Media;
+    whyChooseTitle: Attribute.String &
+      Attribute.DefaultTo<'\u00BFPor qu\u00E9 elegir Espa\u00F1a?'>;
+    whyChooseItems: Attribute.JSON;
+    hospitalityTitle: Attribute.String & Attribute.DefaultTo<'Cultura Rica'>;
+    hospitalityDescription: Attribute.String &
+      Attribute.DefaultTo<'Pa\u00EDs con rica historia y tradiciones culturales'>;
+    hospitalityIcon: Attribute.String & Attribute.DefaultTo<'\uD83C\uDFAD'>;
+    educationTitle: Attribute.String &
+      Attribute.DefaultTo<'Educaci\u00F3n de Calidad'>;
+    educationDescription: Attribute.String &
+      Attribute.DefaultTo<'Universidades de prestigio con costos accesibles'>;
+    educationIcon: Attribute.String & Attribute.DefaultTo<'\uD83C\uDF93'>;
+    cultureTitle: Attribute.String & Attribute.DefaultTo<'Idioma Espa\u00F1ol'>;
+    cultureDescription: Attribute.String &
+      Attribute.DefaultTo<'Espa\u00F1ol como idioma oficial en su cuna'>;
+    cultureIcon: Attribute.String & Attribute.DefaultTo<'\uD83D\uDDE3\uFE0F'>;
+    languageTitle: Attribute.String &
+      Attribute.DefaultTo<'Clima Mediterr\u00E1neo'>;
+    languageDescription: Attribute.String &
+      Attribute.DefaultTo<'Excelente clima y calidad de vida mediterr\u00E1nea'>;
+    languageIcon: Attribute.String & Attribute.DefaultTo<'\u2600\uFE0F'>;
+    qualityTitle: Attribute.String & Attribute.DefaultTo<'Calidad de Vida'>;
+    qualityDescription: Attribute.String &
+      Attribute.DefaultTo<'Excelente calidad de vida y servicios p\u00FAblicos'>;
+    qualityIcon: Attribute.String & Attribute.DefaultTo<'\uD83C\uDFE0'>;
+    opportunitiesTitle: Attribute.String &
+      Attribute.DefaultTo<'Oportunidades Profesionales'>;
+    opportunitiesDescription: Attribute.String &
+      Attribute.DefaultTo<'Carrera en empresas europeas y startups'>;
+    opportunitiesIcon: Attribute.String & Attribute.DefaultTo<'\uD83D\uDCBC'>;
+    statisticsTitle: Attribute.String &
+      Attribute.DefaultTo<'Espa\u00F1a en n\u00FAmeros'>;
+    statistics: Attribute.JSON;
+    featuresTitle: Attribute.String &
+      Attribute.DefaultTo<'Caracter\u00EDsticas de Espa\u00F1a'>;
+    features: Attribute.JSON;
+    travelTipsTitle: Attribute.String &
+      Attribute.DefaultTo<'Tips de viaje para Espa\u00F1a'>;
+    travelTips: Attribute.JSON;
+    programs: Attribute.JSON;
+    requirements: Attribute.JSON;
+    overview: Attribute.JSON;
+    highlights: Attribute.JSON;
+    pricing: Attribute.JSON;
+    accommodation: Attribute.JSON;
+    transportation: Attribute.JSON;
+    climate: Attribute.JSON;
+    culture: Attribute.JSON;
+    education: Attribute.JSON;
+    workOpportunities: Attribute.JSON;
+    visaInfo: Attribute.JSON;
+    costOfLiving: Attribute.JSON;
+    safety: Attribute.JSON;
+    attractions: Attribute.JSON;
+    events: Attribute.JSON;
+    testimonials: Attribute.JSON;
+    faq: Attribute.JSON;
+    seoTitle: Attribute.String;
+    seoDescription: Attribute.Text;
+    seoKeywords: Attribute.JSON;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    publishedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<
+      'api::spain.spain',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<
+      'api::spain.spain',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+  };
+}
+
+export interface ApiThailandThailand extends Schema.CollectionType {
+  collectionName: 'thailands';
+  info: {
+    singularName: 'thailand';
+    pluralName: 'thailands';
+    displayName: 'Thailand';
+    description: 'Informaci\u00F3n detallada sobre Tailandia como destino de estudio y trabajo';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    title: Attribute.String &
+      Attribute.Required &
+      Attribute.SetMinMaxLength<{
+        maxLength: 255;
+      }> &
+      Attribute.DefaultTo<'Thailand'>;
+    slug: Attribute.UID<'api::thailand.thailand', 'title'> & Attribute.Required;
+    description: Attribute.RichText & Attribute.Required;
+    shortDescription: Attribute.Text &
+      Attribute.SetMinMaxLength<{
+        maxLength: 500;
+      }>;
+    image: Attribute.Media & Attribute.Required;
+    gallery: Attribute.Media;
+    whyChooseTitle: Attribute.String &
+      Attribute.DefaultTo<'\u00BFPor qu\u00E9 elegir Tailandia?'>;
+    whyChooseItems: Attribute.JSON;
+    hospitalityTitle: Attribute.String &
+      Attribute.DefaultTo<'Hospitalidad Tailandesa'>;
+    hospitalityDescription: Attribute.String &
+      Attribute.DefaultTo<'Experiencia en la famosa hospitalidad tailandesa y turismo'>;
+    hospitalityIcon: Attribute.String & Attribute.DefaultTo<'\uD83D\uDE4F'>;
+    educationTitle: Attribute.String & Attribute.DefaultTo<'Cultura Rica'>;
+    educationDescription: Attribute.String &
+      Attribute.DefaultTo<'Inmersi\u00F3n en una de las culturas m\u00E1s fascinantes del mundo'>;
+    educationIcon: Attribute.String & Attribute.DefaultTo<'\uD83C\uDFDB\uFE0F'>;
+    cultureTitle: Attribute.String & Attribute.DefaultTo<'Costo de Vida Bajo'>;
+    cultureDescription: Attribute.String &
+      Attribute.DefaultTo<'Excelente relaci\u00F3n calidad-precio para vivir y estudiar'>;
+    cultureIcon: Attribute.String & Attribute.DefaultTo<'\uD83D\uDCB0'>;
+    languageTitle: Attribute.String &
+      Attribute.DefaultTo<'Aprendizaje de Idiomas'>;
+    languageDescription: Attribute.String &
+      Attribute.DefaultTo<'Mejora tu ingl\u00E9s y aprende tailand\u00E9s b\u00E1sico'>;
+    languageIcon: Attribute.String & Attribute.DefaultTo<'\uD83D\uDDE3\uFE0F'>;
+    qualityTitle: Attribute.String &
+      Attribute.DefaultTo<'Aventura y Naturaleza'>;
+    qualityDescription: Attribute.String &
+      Attribute.DefaultTo<'Playas paradis\u00EDacas, monta\u00F1as y selvas tropicales'>;
+    qualityIcon: Attribute.String & Attribute.DefaultTo<'\uD83C\uDFDD\uFE0F'>;
+    opportunitiesTitle: Attribute.String &
+      Attribute.DefaultTo<'Oportunidades de Negocio'>;
+    opportunitiesDescription: Attribute.String &
+      Attribute.DefaultTo<'Centro de negocios en el sudeste asi\u00E1tico'>;
+    opportunitiesIcon: Attribute.String & Attribute.DefaultTo<'\uD83D\uDCBC'>;
+    statisticsTitle: Attribute.String &
+      Attribute.DefaultTo<'Tailandia en n\u00FAmeros'>;
+    statistics: Attribute.JSON;
+    featuresTitle: Attribute.String &
+      Attribute.DefaultTo<'Caracter\u00EDsticas de Tailandia'>;
+    features: Attribute.JSON;
+    travelTipsTitle: Attribute.String &
+      Attribute.DefaultTo<'Tips de viaje para Tailandia'>;
+    travelTips: Attribute.JSON;
+    programs: Attribute.JSON;
+    requirements: Attribute.JSON;
+    overview: Attribute.JSON;
+    highlights: Attribute.JSON;
+    pricing: Attribute.JSON;
+    accommodation: Attribute.JSON;
+    transportation: Attribute.JSON;
+    climate: Attribute.JSON;
+    culture: Attribute.JSON;
+    education: Attribute.JSON;
+    workOpportunities: Attribute.JSON;
+    visaInfo: Attribute.JSON;
+    costOfLiving: Attribute.JSON;
+    safety: Attribute.JSON;
+    attractions: Attribute.JSON;
+    events: Attribute.JSON;
+    testimonials: Attribute.JSON;
+    faq: Attribute.JSON;
+    seoTitle: Attribute.String;
+    seoDescription: Attribute.Text;
+    seoKeywords: Attribute.JSON;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    publishedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<
+      'api::thailand.thailand',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<
+      'api::thailand.thailand',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+  };
+}
+
+export interface ApiUnitedKingdomUnitedKingdom extends Schema.CollectionType {
+  collectionName: 'united_kingdoms';
+  info: {
+    singularName: 'united-kingdom';
+    pluralName: 'united-kingdoms';
+    displayName: 'United Kingdom';
+    description: 'Informaci\u00F3n detallada sobre Reino Unido como destino de estudio y trabajo';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    title: Attribute.String &
+      Attribute.Required &
+      Attribute.SetMinMaxLength<{
+        maxLength: 255;
+      }> &
+      Attribute.DefaultTo<'United Kingdom'>;
+    slug: Attribute.UID<'api::united-kingdom.united-kingdom', 'title'> &
+      Attribute.Required;
+    description: Attribute.RichText & Attribute.Required;
+    shortDescription: Attribute.Text &
+      Attribute.SetMinMaxLength<{
+        maxLength: 500;
+      }>;
+    image: Attribute.Media & Attribute.Required;
+    gallery: Attribute.Media;
+    whyChooseTitle: Attribute.String &
+      Attribute.DefaultTo<'\u00BFPor qu\u00E9 elegir Reino Unido?'>;
+    whyChooseItems: Attribute.JSON;
+    hospitalityTitle: Attribute.String &
+      Attribute.DefaultTo<'Historia Milenaria'>;
+    hospitalityDescription: Attribute.String &
+      Attribute.DefaultTo<'Pa\u00EDs con rica historia y tradiciones ancestrales'>;
+    hospitalityIcon: Attribute.String & Attribute.DefaultTo<'\uD83C\uDFF0'>;
+    educationTitle: Attribute.String &
+      Attribute.DefaultTo<'Educaci\u00F3n de Excelencia'>;
+    educationDescription: Attribute.String &
+      Attribute.DefaultTo<'Universidades de prestigio mundial'>;
+    educationIcon: Attribute.String & Attribute.DefaultTo<'\uD83C\uDF93'>;
+    cultureTitle: Attribute.String &
+      Attribute.DefaultTo<'Cultura Brit\u00E1nica'>;
+    cultureDescription: Attribute.String &
+      Attribute.DefaultTo<'Inmersi\u00F3n en la cultura brit\u00E1nica y europea'>;
+    cultureIcon: Attribute.String &
+      Attribute.DefaultTo<'\uD83C\uDDEC\uD83C\uDDE7'>;
+    languageTitle: Attribute.String & Attribute.DefaultTo<'Idioma Ingl\u00E9s'>;
+    languageDescription: Attribute.String &
+      Attribute.DefaultTo<'Ingl\u00E9s como idioma oficial en su cuna'>;
+    languageIcon: Attribute.String & Attribute.DefaultTo<'\uD83D\uDDE3\uFE0F'>;
+    qualityTitle: Attribute.String & Attribute.DefaultTo<'Calidad de Vida'>;
+    qualityDescription: Attribute.String &
+      Attribute.DefaultTo<'Excelente calidad de vida y servicios p\u00FAblicos'>;
+    qualityIcon: Attribute.String & Attribute.DefaultTo<'\uD83C\uDFE0'>;
+    opportunitiesTitle: Attribute.String &
+      Attribute.DefaultTo<'Oportunidades Profesionales'>;
+    opportunitiesDescription: Attribute.String &
+      Attribute.DefaultTo<'Carrera en empresas multinacionales y startups'>;
+    opportunitiesIcon: Attribute.String & Attribute.DefaultTo<'\uD83D\uDCBC'>;
+    statisticsTitle: Attribute.String &
+      Attribute.DefaultTo<'Reino Unido en n\u00FAmeros'>;
+    statistics: Attribute.JSON;
+    featuresTitle: Attribute.String &
+      Attribute.DefaultTo<'Caracter\u00EDsticas del Reino Unido'>;
+    features: Attribute.JSON;
+    travelTipsTitle: Attribute.String &
+      Attribute.DefaultTo<'Tips de viaje para Reino Unido'>;
+    travelTips: Attribute.JSON;
+    programs: Attribute.JSON;
+    requirements: Attribute.JSON;
+    overview: Attribute.JSON;
+    highlights: Attribute.JSON;
+    pricing: Attribute.JSON;
+    accommodation: Attribute.JSON;
+    transportation: Attribute.JSON;
+    climate: Attribute.JSON;
+    culture: Attribute.JSON;
+    education: Attribute.JSON;
+    workOpportunities: Attribute.JSON;
+    visaInfo: Attribute.JSON;
+    costOfLiving: Attribute.JSON;
+    safety: Attribute.JSON;
+    attractions: Attribute.JSON;
+    events: Attribute.JSON;
+    testimonials: Attribute.JSON;
+    faq: Attribute.JSON;
+    seoTitle: Attribute.String;
+    seoDescription: Attribute.Text;
+    seoKeywords: Attribute.JSON;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    publishedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<
+      'api::united-kingdom.united-kingdom',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<
+      'api::united-kingdom.united-kingdom',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+  };
+}
+
+export interface ApiUnitedStateUnitedState extends Schema.CollectionType {
+  collectionName: 'united_states';
+  info: {
+    singularName: 'united-state';
+    pluralName: 'united-states';
+    displayName: 'United States';
+    description: 'Informaci\u00F3n detallada sobre Estados Unidos como destino de estudio y trabajo';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    title: Attribute.String &
+      Attribute.Required &
+      Attribute.SetMinMaxLength<{
+        maxLength: 255;
+      }> &
+      Attribute.DefaultTo<'United States'>;
+    slug: Attribute.UID<'api::united-state.united-state', 'title'> &
+      Attribute.Required;
+    description: Attribute.RichText & Attribute.Required;
+    shortDescription: Attribute.Text &
+      Attribute.SetMinMaxLength<{
+        maxLength: 500;
+      }>;
+    image: Attribute.Media & Attribute.Required;
+    gallery: Attribute.Media;
+    whyChooseTitle: Attribute.String &
+      Attribute.DefaultTo<'\u00BFPor qu\u00E9 elegir Estados Unidos?'>;
+    whyChooseItems: Attribute.JSON;
+    hospitalityTitle: Attribute.String &
+      Attribute.DefaultTo<'Educaci\u00F3n de Excelencia'>;
+    hospitalityDescription: Attribute.String &
+      Attribute.DefaultTo<'Universidades de prestigio mundial'>;
+    hospitalityIcon: Attribute.String & Attribute.DefaultTo<'\uD83C\uDF93'>;
+    educationTitle: Attribute.String &
+      Attribute.DefaultTo<'Oportunidades Profesionales'>;
+    educationDescription: Attribute.String &
+      Attribute.DefaultTo<'Carrera en empresas multinacionales y startups'>;
+    educationIcon: Attribute.String & Attribute.DefaultTo<'\uD83D\uDCBC'>;
+    cultureTitle: Attribute.String & Attribute.DefaultTo<'Cultura Diversa'>;
+    cultureDescription: Attribute.String &
+      Attribute.DefaultTo<'Pa\u00EDs multicultural con diversidad \u00E9tnica'>;
+    cultureIcon: Attribute.String & Attribute.DefaultTo<'\uD83C\uDF0D'>;
+    languageTitle: Attribute.String & Attribute.DefaultTo<'Idioma Ingl\u00E9s'>;
+    languageDescription: Attribute.String &
+      Attribute.DefaultTo<'Ingl\u00E9s como idioma oficial en su cuna'>;
+    languageIcon: Attribute.String & Attribute.DefaultTo<'\uD83D\uDDE3\uFE0F'>;
+    qualityTitle: Attribute.String & Attribute.DefaultTo<'Calidad de Vida'>;
+    qualityDescription: Attribute.String &
+      Attribute.DefaultTo<'Excelente calidad de vida y servicios p\u00FAblicos'>;
+    qualityIcon: Attribute.String & Attribute.DefaultTo<'\uD83C\uDFE0'>;
+    opportunitiesTitle: Attribute.String &
+      Attribute.DefaultTo<'Innovaci\u00F3n Tecnol\u00F3gica'>;
+    opportunitiesDescription: Attribute.String &
+      Attribute.DefaultTo<'Hub tecnol\u00F3gico mundial con oportunidades \u00FAnicas'>;
+    opportunitiesIcon: Attribute.String & Attribute.DefaultTo<'\uD83D\uDCBB'>;
+    statisticsTitle: Attribute.String &
+      Attribute.DefaultTo<'Estados Unidos en n\u00FAmeros'>;
+    statistics: Attribute.JSON;
+    featuresTitle: Attribute.String &
+      Attribute.DefaultTo<'Caracter\u00EDsticas de Estados Unidos'>;
+    features: Attribute.JSON;
+    travelTipsTitle: Attribute.String &
+      Attribute.DefaultTo<'Tips de viaje para Estados Unidos'>;
+    travelTips: Attribute.JSON;
+    programs: Attribute.JSON;
+    requirements: Attribute.JSON;
+    overview: Attribute.JSON;
+    highlights: Attribute.JSON;
+    pricing: Attribute.JSON;
+    accommodation: Attribute.JSON;
+    transportation: Attribute.JSON;
+    climate: Attribute.JSON;
+    culture: Attribute.JSON;
+    education: Attribute.JSON;
+    workOpportunities: Attribute.JSON;
+    visaInfo: Attribute.JSON;
+    costOfLiving: Attribute.JSON;
+    safety: Attribute.JSON;
+    attractions: Attribute.JSON;
+    events: Attribute.JSON;
+    testimonials: Attribute.JSON;
+    faq: Attribute.JSON;
+    seoTitle: Attribute.String;
+    seoDescription: Attribute.Text;
+    seoKeywords: Attribute.JSON;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    publishedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<
+      'api::united-state.united-state',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<
+      'api::united-state.united-state',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+  };
+}
+
+export interface ApiVietnamVietnam extends Schema.CollectionType {
+  collectionName: 'vietnams';
+  info: {
+    singularName: 'vietnam';
+    pluralName: 'vietnams';
+    displayName: 'Vietnam';
+    description: 'Informaci\u00F3n detallada sobre Vietnam como destino de estudio y trabajo';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    title: Attribute.String &
+      Attribute.Required &
+      Attribute.SetMinMaxLength<{
+        maxLength: 255;
+      }> &
+      Attribute.DefaultTo<'Vietnam'>;
+    slug: Attribute.UID<'api::vietnam.vietnam', 'title'> & Attribute.Required;
+    description: Attribute.RichText & Attribute.Required;
+    shortDescription: Attribute.Text &
+      Attribute.SetMinMaxLength<{
+        maxLength: 500;
+      }>;
+    image: Attribute.Media & Attribute.Required;
+    gallery: Attribute.Media;
+    whyChooseTitle: Attribute.String &
+      Attribute.DefaultTo<'\u00BFPor qu\u00E9 elegir Vietnam?'>;
+    whyChooseItems: Attribute.JSON;
+    hospitalityTitle: Attribute.String &
+      Attribute.DefaultTo<'Cultura Milenaria'>;
+    hospitalityDescription: Attribute.String &
+      Attribute.DefaultTo<'Inmersi\u00F3n en una de las culturas m\u00E1s ricas del sudeste asi\u00E1tico'>;
+    hospitalityIcon: Attribute.String &
+      Attribute.DefaultTo<'\uD83C\uDFDB\uFE0F'>;
+    educationTitle: Attribute.String &
+      Attribute.DefaultTo<'Costo de Vida Bajo'>;
+    educationDescription: Attribute.String &
+      Attribute.DefaultTo<'Excelente relaci\u00F3n calidad-precio para vivir y estudiar'>;
+    educationIcon: Attribute.String & Attribute.DefaultTo<'\uD83D\uDCB0'>;
+    cultureTitle: Attribute.String &
+      Attribute.DefaultTo<'Gastronom\u00EDa Mundial'>;
+    cultureDescription: Attribute.String &
+      Attribute.DefaultTo<'Una de las cocinas m\u00E1s reconocidas internacionalmente'>;
+    cultureIcon: Attribute.String & Attribute.DefaultTo<'\uD83C\uDF5C'>;
+    languageTitle: Attribute.String &
+      Attribute.DefaultTo<'Aprendizaje de Idiomas'>;
+    languageDescription: Attribute.String &
+      Attribute.DefaultTo<'Mejora tu ingl\u00E9s y aprende vietnamita b\u00E1sico'>;
+    languageIcon: Attribute.String & Attribute.DefaultTo<'\uD83D\uDDE3\uFE0F'>;
+    qualityTitle: Attribute.String &
+      Attribute.DefaultTo<'Naturaleza Exuberante'>;
+    qualityDescription: Attribute.String &
+      Attribute.DefaultTo<'Desde monta\u00F1as hasta playas tropicales'>;
+    qualityIcon: Attribute.String & Attribute.DefaultTo<'\uD83C\uDFD4\uFE0F'>;
+    opportunitiesTitle: Attribute.String &
+      Attribute.DefaultTo<'Oportunidades de Negocio'>;
+    opportunitiesDescription: Attribute.String &
+      Attribute.DefaultTo<'Econom\u00EDa en crecimiento con muchas oportunidades'>;
+    opportunitiesIcon: Attribute.String & Attribute.DefaultTo<'\uD83D\uDCBC'>;
+    statisticsTitle: Attribute.String &
+      Attribute.DefaultTo<'Vietnam en n\u00FAmeros'>;
+    statistics: Attribute.JSON;
+    featuresTitle: Attribute.String &
+      Attribute.DefaultTo<'Caracter\u00EDsticas de Vietnam'>;
+    features: Attribute.JSON;
+    travelTipsTitle: Attribute.String &
+      Attribute.DefaultTo<'Tips de viaje para Vietnam'>;
+    travelTips: Attribute.JSON;
+    programs: Attribute.JSON;
+    requirements: Attribute.JSON;
+    overview: Attribute.JSON;
+    highlights: Attribute.JSON;
+    pricing: Attribute.JSON;
+    accommodation: Attribute.JSON;
+    transportation: Attribute.JSON;
+    climate: Attribute.JSON;
+    culture: Attribute.JSON;
+    education: Attribute.JSON;
+    workOpportunities: Attribute.JSON;
+    visaInfo: Attribute.JSON;
+    costOfLiving: Attribute.JSON;
+    safety: Attribute.JSON;
+    attractions: Attribute.JSON;
+    events: Attribute.JSON;
+    testimonials: Attribute.JSON;
+    faq: Attribute.JSON;
+    seoTitle: Attribute.String;
+    seoDescription: Attribute.Text;
+    seoKeywords: Attribute.JSON;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    publishedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<
+      'api::vietnam.vietnam',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<
+      'api::vietnam.vietnam',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+  };
+}
+
 declare module '@strapi/types' {
   export module Shared {
     export interface ContentTypes {
@@ -806,6 +2393,21 @@ declare module '@strapi/types' {
       'plugin::users-permissions.role': PluginUsersPermissionsRole;
       'plugin::users-permissions.user': PluginUsersPermissionsUser;
       'plugin::i18n.locale': PluginI18NLocale;
+      'api::abu-dhabi.abu-dhabi': ApiAbuDhabiAbuDhabi;
+      'api::australia.australia': ApiAustraliaAustralia;
+      'api::canada.canada': ApiCanadaCanada;
+      'api::dubai.dubai': ApiDubaiDubai;
+      'api::hong-kong.hong-kong': ApiHongKongHongKong;
+      'api::ireland.ireland': ApiIrelandIreland;
+      'api::maldive.maldive': ApiMaldiveMaldive;
+      'api::malta.malta': ApiMaltaMalta;
+      'api::prague.prague': ApiPraguePrague;
+      'api::qatar.qatar': ApiQatarQatar;
+      'api::spain.spain': ApiSpainSpain;
+      'api::thailand.thailand': ApiThailandThailand;
+      'api::united-kingdom.united-kingdom': ApiUnitedKingdomUnitedKingdom;
+      'api::united-state.united-state': ApiUnitedStateUnitedState;
+      'api::vietnam.vietnam': ApiVietnamVietnam;
     }
   }
 }


### PR DESCRIPTION
- Create destination collections: Ireland, Qatar, Thailand, Hong Kong, Maldives, Abu Dhabi, Vietnam, Dubai, Prague, Malta, Canada, Australia, United Kingdom, Spain, United States
- Configure schemas with comprehensive fields for travel information
- Set up controllers, routes, and services for each destination
- Add custom routes for enhanced API endpoints
- Fix Strapi naming convention issues (singularName/pluralName alignment)
- Resolve content-type key validation errors
- Ensure consistent structure across all destination collections