### PR TITLE
feat: add program collection with complete API structure

### DIFF
--- a/src/api/program/content-types/program/schema.json
+++ b/src/api/program/content-types/program/schema.json
@@ -1,0 +1,159 @@
+{
+  "kind": "collectionType",
+  "collectionName": "programs",
+  "info": {
+    "singularName": "program",
+    "pluralName": "programs",
+    "displayName": "Programa",
+    "description": "Programas de estudio y trabajo en el extranjero"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "title": {
+      "type": "string",
+      "required": true,
+      "maxLength": 255
+    },
+    "slug": {
+      "type": "uid",
+      "targetField": "title",
+      "required": true
+    },
+    "description": {
+      "type": "richtext",
+      "required": true
+    },
+    "shortDescription": {
+      "type": "text",
+      "maxLength": 500
+    },
+    "programType": {
+      "type": "enumeration",
+      "enum": [
+        "work-and-travel",
+        "estudios-exterior",
+        "practicas-pasantias",
+        "au-pair",
+        "voluntariados"
+      ],
+      "required": true
+    },
+    "duration": {
+      "type": "string",
+      "required": true
+    },
+    "price": {
+      "type": "decimal",
+      "required": true
+    },
+    "currency": {
+      "type": "string",
+      "default": "USD"
+    },
+    "featuredImage": {
+      "type": "media",
+      "multiple": false,
+      "required": true,
+      "allowedTypes": ["images"]
+    },
+    "gallery": {
+      "type": "media",
+      "multiple": true,
+      "allowedTypes": ["images"]
+    },
+    "featured": {
+      "type": "boolean",
+      "default": false
+    },
+    "active": {
+      "type": "boolean",
+      "default": true
+    },
+    "destination": {
+      "type": "relation",
+      "relation": "manyToOne",
+      "target": "api::destination.destination"
+    },
+    "ageRange": {
+      "type": "json"
+    },
+    "requirements": {
+      "type": "json"
+    },
+    "inclusions": {
+      "type": "json"
+    },
+    "exclusions": {
+      "type": "json"
+    },
+    "itinerary": {
+      "type": "json"
+    },
+    "accommodation": {
+      "type": "json"
+    },
+    "meals": {
+      "type": "json"
+    },
+    "transportation": {
+      "type": "json"
+    },
+    "activities": {
+      "type": "json"
+    },
+    "support": {
+      "type": "json"
+    },
+    "certification": {
+      "type": "json"
+    },
+    "languageRequirements": {
+      "type": "json"
+    },
+    "applicationProcess": {
+      "type": "json"
+    },
+    "deadlines": {
+      "type": "json"
+    },
+    "testimonials": {
+      "type": "json"
+    },
+    "faq": {
+      "type": "json"
+    },
+    "pricing": {
+      "type": "json"
+    },
+    "benefits": {
+      "type": "json"
+    },
+    "careerOpportunities": {
+      "type": "json"
+    },
+    "culturalExperience": {
+      "type": "json"
+    },
+    "safety": {
+      "type": "json"
+    },
+    "insurance": {
+      "type": "json"
+    },
+    "visaSupport": {
+      "type": "json"
+    },
+    "seoTitle": {
+      "type": "string"
+    },
+    "seoDescription": {
+      "type": "text"
+    },
+    "seoKeywords": {
+      "type": "json"
+    }
+  }
+}

--- a/src/api/program/controllers/program.js
+++ b/src/api/program/controllers/program.js
@@ -1,0 +1,211 @@
+'use strict';
+
+/**
+ * program controller
+ */
+
+const { createCoreController } = require('@strapi/strapi').factories;
+
+module.exports = createCoreController('api::program.program', ({ strapi }) => ({
+  // Método personalizado para obtener programas por tipo
+  async findByType(ctx) {
+    const { programType } = ctx.params;
+    
+    const entities = await strapi.entityService.findMany('api::program.program', {
+      filters: { 
+        active: true,
+        programType: programType
+      },
+      populate: {
+        featuredImage: true,
+        destination: true
+      }
+    });
+
+    return entities;
+  },
+
+  // Método personalizado para obtener programas destacados
+  async findFeatured(ctx) {
+    const entities = await strapi.entityService.findMany('api::program.program', {
+      filters: { 
+        active: true,
+        featured: true
+      },
+      populate: {
+        featuredImage: true,
+        destination: true
+      }
+    });
+
+    return entities;
+  },
+
+  // Método personalizado para obtener programas por destino
+  async findByDestination(ctx) {
+    const { destinationId } = ctx.params;
+    
+    const entities = await strapi.entityService.findMany('api::program.program', {
+      filters: { 
+        active: true,
+        destination: destinationId
+      },
+      populate: {
+        featuredImage: true,
+        destination: true
+      }
+    });
+
+    return entities;
+  },
+
+  // Método personalizado para obtener información completa de un programa
+  async findComplete(ctx) {
+    const entities = await strapi.entityService.findMany('api::program.program', {
+      filters: { active: true },
+      populate: {
+        featuredImage: true,
+        gallery: true,
+        destination: true
+      }
+    });
+
+    return entities;
+  },
+
+  // Método personalizado para obtener programas por rango de precio
+  async findByPriceRange(ctx) {
+    const { minPrice, maxPrice } = ctx.query;
+    
+    const filters = { active: true };
+    
+    if (minPrice) {
+      filters.price = { $gte: parseFloat(minPrice) };
+    }
+    
+    if (maxPrice) {
+      filters.price = { 
+        ...filters.price,
+        $lte: parseFloat(maxPrice)
+      };
+    }
+
+    const entities = await strapi.entityService.findMany('api::program.program', {
+      filters,
+      populate: {
+        featuredImage: true,
+        destination: true
+      }
+    });
+
+    return entities;
+  },
+
+  // Método personalizado para obtener programas por duración
+  async findByDuration(ctx) {
+    const { duration } = ctx.params;
+    
+    const entities = await strapi.entityService.findMany('api::program.program', {
+      filters: { 
+        active: true,
+        duration: duration
+      },
+      populate: {
+        featuredImage: true,
+        destination: true
+      }
+    });
+
+    return entities;
+  },
+
+  // Método personalizado para obtener estadísticas de programas
+  async findStats(ctx) {
+    const entities = await strapi.entityService.findMany('api::program.program', {
+      filters: { active: true },
+      populate: {
+        featuredImage: true
+      }
+    });
+
+    // Calcular estadísticas
+    const stats = {
+      totalPrograms: entities.length,
+      programsByType: {},
+      averagePrice: 0,
+      priceRange: { min: 0, max: 0 }
+    };
+
+    let totalPrice = 0;
+    let minPrice = Infinity;
+    let maxPrice = 0;
+
+    entities.forEach(program => {
+      // Contar por tipo
+      if (!stats.programsByType[program.programType]) {
+        stats.programsByType[program.programType] = 0;
+      }
+      stats.programsByType[program.programType]++;
+
+      // Calcular precios
+      if (program.price) {
+        totalPrice += program.price;
+        minPrice = Math.min(minPrice, program.price);
+        maxPrice = Math.max(maxPrice, program.price);
+      }
+    });
+
+    stats.averagePrice = entities.length > 0 ? totalPrice / entities.length : 0;
+    stats.priceRange = { min: minPrice === Infinity ? 0 : minPrice, max: maxPrice };
+
+    return stats;
+  },
+
+  // Método personalizado para búsqueda de programas
+  async search(ctx) {
+    const { q, type, destination, minPrice, maxPrice, duration } = ctx.query;
+    
+    const filters = { active: true };
+    
+    // Filtro por texto de búsqueda
+    if (q) {
+      filters.$or = [
+        { title: { $containsi: q } },
+        { description: { $containsi: q } },
+        { shortDescription: { $containsi: q } }
+      ];
+    }
+    
+    // Filtro por tipo
+    if (type) {
+      filters.programType = type;
+    }
+    
+    // Filtro por destino
+    if (destination) {
+      filters.destination = destination;
+    }
+    
+    // Filtro por precio
+    if (minPrice || maxPrice) {
+      filters.price = {};
+      if (minPrice) filters.price.$gte = parseFloat(minPrice);
+      if (maxPrice) filters.price.$lte = parseFloat(maxPrice);
+    }
+    
+    // Filtro por duración
+    if (duration) {
+      filters.duration = duration;
+    }
+
+    const entities = await strapi.entityService.findMany('api::program.program', {
+      filters,
+      populate: {
+        featuredImage: true,
+        destination: true
+      }
+    });
+
+    return entities;
+  }
+}));

--- a/src/api/program/routes/custom-routes.js
+++ b/src/api/program/routes/custom-routes.js
@@ -1,0 +1,74 @@
+'use strict';
+
+/**
+ * Custom routes for program
+ */
+
+module.exports = {
+  routes: [
+    {
+      method: 'GET',
+      path: '/programs/type/:programType',
+      handler: 'program.findByType',
+      config: {
+        auth: false,
+      },
+    },
+    {
+      method: 'GET',
+      path: '/programs/featured',
+      handler: 'program.findFeatured',
+      config: {
+        auth: false,
+      },
+    },
+    {
+      method: 'GET',
+      path: '/programs/destination/:destinationId',
+      handler: 'program.findByDestination',
+      config: {
+        auth: false,
+      },
+    },
+    {
+      method: 'GET',
+      path: '/programs/complete',
+      handler: 'program.findComplete',
+      config: {
+        auth: false,
+      },
+    },
+    {
+      method: 'GET',
+      path: '/programs/price-range',
+      handler: 'program.findByPriceRange',
+      config: {
+        auth: false,
+      },
+    },
+    {
+      method: 'GET',
+      path: '/programs/duration/:duration',
+      handler: 'program.findByDuration',
+      config: {
+        auth: false,
+      },
+    },
+    {
+      method: 'GET',
+      path: '/programs/stats',
+      handler: 'program.findStats',
+      config: {
+        auth: false,
+      },
+    },
+    {
+      method: 'GET',
+      path: '/programs/search',
+      handler: 'program.search',
+      config: {
+        auth: false,
+      },
+    },
+  ],
+};

--- a/src/api/program/routes/program.js
+++ b/src/api/program/routes/program.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * program router
+ */
+
+const { createCoreRouter } = require('@strapi/strapi').factories;
+
+module.exports = createCoreRouter('api::program.program');

--- a/src/api/program/services/program.js
+++ b/src/api/program/services/program.js
@@ -1,0 +1,216 @@
+'use strict';
+
+/**
+ * program service
+ */
+
+const { createCoreService } = require('@strapi/strapi').factories;
+
+module.exports = createCoreService('api::program.program', ({ strapi }) => ({
+  // Método personalizado para obtener programas con información completa
+  async findWithFullData(params = {}) {
+    const { data, meta } = await strapi.entityService.findMany('api::program.program', {
+      ...params,
+      populate: {
+        featuredImage: true,
+        gallery: true,
+        destination: {
+          populate: {
+            image: true
+          }
+        }
+      }
+    });
+
+    return { data, meta };
+  },
+
+  // Método personalizado para obtener programas por tipo con paginación
+  async findByTypeWithPagination(programType, page = 1, pageSize = 10) {
+    const { data, meta } = await strapi.entityService.findMany('api::program.program', {
+      filters: { 
+        active: true,
+        programType: programType
+      },
+      populate: {
+        featuredImage: true,
+        destination: true
+      },
+      pagination: {
+        page: page,
+        pageSize: pageSize
+      }
+    });
+
+    return { data, meta };
+  },
+
+  // Método personalizado para obtener programas relacionados
+  async findRelated(programId, limit = 4) {
+    // Primero obtenemos el programa actual
+    const currentProgram = await strapi.entityService.findOne('api::program.program', programId, {
+      populate: {
+        destination: true
+      }
+    });
+
+    if (!currentProgram) {
+      return [];
+    }
+
+    // Buscamos programas relacionados por destino y tipo
+    const relatedPrograms = await strapi.entityService.findMany('api::program.program', {
+      filters: {
+        id: { $ne: programId },
+        active: true,
+        $or: [
+          { destination: currentProgram.destination?.id },
+          { programType: currentProgram.programType }
+        ]
+      },
+      populate: {
+        featuredImage: true,
+        destination: true
+      },
+      pagination: {
+        limit: limit
+      }
+    });
+
+    return relatedPrograms;
+  },
+
+  // Método personalizado para obtener estadísticas avanzadas
+  async getAdvancedStats() {
+    const programs = await strapi.entityService.findMany('api::program.program', {
+      filters: { active: true },
+      populate: {
+        destination: true
+      }
+    });
+
+    const stats = {
+      totalPrograms: programs.length,
+      programsByType: {},
+      programsByDestination: {},
+      priceStatistics: {
+        average: 0,
+        median: 0,
+        min: Infinity,
+        max: 0
+      },
+      durationStatistics: {},
+      featuredPrograms: 0
+    };
+
+    const prices = [];
+    let totalPrice = 0;
+
+    programs.forEach(program => {
+      // Contar por tipo
+      if (!stats.programsByType[program.programType]) {
+        stats.programsByType[program.programType] = 0;
+      }
+      stats.programsByType[program.programType]++;
+
+      // Contar por destino
+      if (program.destination) {
+        const destName = program.destination.name || program.destination.title;
+        if (!stats.programsByDestination[destName]) {
+          stats.programsByDestination[destName] = 0;
+        }
+        stats.programsByDestination[destName]++;
+      }
+
+      // Estadísticas de precio
+      if (program.price) {
+        prices.push(program.price);
+        totalPrice += program.price;
+        stats.priceStatistics.min = Math.min(stats.priceStatistics.min, program.price);
+        stats.priceStatistics.max = Math.max(stats.priceStatistics.max, program.price);
+      }
+
+      // Estadísticas de duración
+      if (program.duration) {
+        if (!stats.durationStatistics[program.duration]) {
+          stats.durationStatistics[program.duration] = 0;
+        }
+        stats.durationStatistics[program.duration]++;
+      }
+
+      // Contar destacados
+      if (program.featured) {
+        stats.featuredPrograms++;
+      }
+    });
+
+    // Calcular estadísticas de precio
+    if (prices.length > 0) {
+      stats.priceStatistics.average = totalPrice / prices.length;
+      
+      // Calcular mediana
+      const sortedPrices = prices.sort((a, b) => a - b);
+      const mid = Math.floor(sortedPrices.length / 2);
+      stats.priceStatistics.median = sortedPrices.length % 2 === 0 
+        ? (sortedPrices[mid - 1] + sortedPrices[mid]) / 2 
+        : sortedPrices[mid];
+    }
+
+    if (stats.priceStatistics.min === Infinity) {
+      stats.priceStatistics.min = 0;
+    }
+
+    return stats;
+  },
+
+  // Método personalizado para validar datos de programa
+  async validateProgramData(data) {
+    const errors = [];
+
+    // Validar campos requeridos
+    if (!data.title) {
+      errors.push('El título es requerido');
+    }
+
+    if (!data.description) {
+      errors.push('La descripción es requerida');
+    }
+
+    if (!data.programType) {
+      errors.push('El tipo de programa es requerido');
+    }
+
+    if (!data.duration) {
+      errors.push('La duración es requerida');
+    }
+
+    if (!data.price || data.price <= 0) {
+      errors.push('El precio debe ser mayor a 0');
+    }
+
+    // Validar tipo de programa
+    const validTypes = ['work-and-travel', 'estudios-exterior', 'practicas-pasantias', 'au-pair', 'voluntariados'];
+    if (data.programType && !validTypes.includes(data.programType)) {
+      errors.push('Tipo de programa no válido');
+    }
+
+    // Validar slug único
+    if (data.slug) {
+      const existingProgram = await strapi.entityService.findMany('api::program.program', {
+        filters: { 
+          slug: data.slug,
+          id: { $ne: data.id }
+        }
+      });
+
+      if (existingProgram.length > 0) {
+        errors.push('El slug ya existe');
+      }
+    }
+
+    return {
+      isValid: errors.length === 0,
+      errors: errors
+    };
+  }
+}));

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -464,6 +464,95 @@ export interface ApiDestinationDestination extends Schema.CollectionType {
   };
 }
 
+export interface ApiProgramProgram extends Schema.CollectionType {
+  collectionName: 'programs';
+  info: {
+    singularName: 'program';
+    pluralName: 'programs';
+    displayName: 'Programa';
+    description: 'Programas de estudio y trabajo en el extranjero';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    title: Attribute.String &
+      Attribute.Required &
+      Attribute.SetMinMaxLength<{
+        maxLength: 255;
+      }>;
+    slug: Attribute.UID<'api::program.program', 'title'> & Attribute.Required;
+    description: Attribute.RichText & Attribute.Required;
+    shortDescription: Attribute.Text &
+      Attribute.SetMinMaxLength<{
+        maxLength: 500;
+      }>;
+    programType: Attribute.Enumeration<
+      [
+        'work-and-travel',
+        'estudios-exterior',
+        'practicas-pasantias',
+        'au-pair',
+        'voluntariados'
+      ]
+    > &
+      Attribute.Required;
+    duration: Attribute.String & Attribute.Required;
+    price: Attribute.Decimal & Attribute.Required;
+    currency: Attribute.String & Attribute.DefaultTo<'USD'>;
+    featuredImage: Attribute.Media & Attribute.Required;
+    gallery: Attribute.Media;
+    featured: Attribute.Boolean & Attribute.DefaultTo<false>;
+    active: Attribute.Boolean & Attribute.DefaultTo<true>;
+    destination: Attribute.Relation<
+      'api::program.program',
+      'manyToOne',
+      'api::destination.destination'
+    >;
+    ageRange: Attribute.JSON;
+    requirements: Attribute.JSON;
+    inclusions: Attribute.JSON;
+    exclusions: Attribute.JSON;
+    itinerary: Attribute.JSON;
+    accommodation: Attribute.JSON;
+    meals: Attribute.JSON;
+    transportation: Attribute.JSON;
+    activities: Attribute.JSON;
+    support: Attribute.JSON;
+    certification: Attribute.JSON;
+    languageRequirements: Attribute.JSON;
+    applicationProcess: Attribute.JSON;
+    deadlines: Attribute.JSON;
+    testimonials: Attribute.JSON;
+    faq: Attribute.JSON;
+    pricing: Attribute.JSON;
+    benefits: Attribute.JSON;
+    careerOpportunities: Attribute.JSON;
+    culturalExperience: Attribute.JSON;
+    safety: Attribute.JSON;
+    insurance: Attribute.JSON;
+    visaSupport: Attribute.JSON;
+    seoTitle: Attribute.String;
+    seoDescription: Attribute.Text;
+    seoKeywords: Attribute.JSON;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    publishedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<
+      'api::program.program',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<
+      'api::program.program',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+  };
+}
+
 export interface PluginUploadFile extends Schema.CollectionType {
   collectionName: 'files';
   info: {
@@ -901,6 +990,7 @@ declare module '@strapi/types' {
       'admin::transfer-token': AdminTransferToken;
       'admin::transfer-token-permission': AdminTransferTokenPermission;
       'api::destination.destination': ApiDestinationDestination;
+      'api::program.program': ApiProgramProgram;
       'plugin::upload.file': PluginUploadFile;
       'plugin::upload.folder': PluginUploadFolder;
       'plugin::content-releases.release': PluginContentReleasesRelease;


### PR DESCRIPTION
- Add program content type with comprehensive schema
- Implement program controller with custom methods
- Create custom routes for program filtering and search
- Add program service with advanced functionality
- Support for 5 program types: work-and-travel, estudios-exterior, practicas-pasantias, au-pair, voluntariados
- Include SEO fields, media management, and relationship with destinations
- Add statistics, search, and filtering capabilities