### PR TITLE
fix(schema): correct relation mapping in destination schema

### DIFF
--- a/src/api/destination/content-types/destination/schema.json
+++ b/src/api/destination/content-types/destination/schema.json
@@ -48,7 +48,7 @@
       "type": "relation",
       "relation": "manyToMany",
       "target": "api::program-type.program-type",
-      "mappedBy": "destinations"
+      "inversedBy": "destinations"
 
     },
     "featured": {


### PR DESCRIPTION
The relation mapping was incorrectly using 'mappedBy' when it should have been 'inversedBy' to properly reflect the manyToMany relationship with program-type.