### PR TITLE
feat(destination): override find method to include default fields

### DIFF
--- a/src/api/destination/controllers/destination.js
+++ b/src/api/destination/controllers/destination.js
@@ -7,6 +7,22 @@
 const { createCoreController } = require('@strapi/strapi').factories;
 
 module.exports = createCoreController('api::destination.destination', ({ strapi }) => ({
+  // Sobrescribir find para incluir campos por defecto
+  async find(ctx) {
+    // Usar entityService directamente para mayor control
+    const entities = await strapi.entityService.findMany('api::destination.destination', {
+      ...ctx.query,
+      populate: {
+        image: true,
+        gallery: true,
+        programTypes: true,
+        ...ctx.query.populate
+      }
+    });
+    
+    return { data: entities, meta: {} };
+  },
+
   // Método personalizado para obtener información completa de un destino
   async findComplete(ctx) {
     const entities = await strapi.entityService.findMany('api::destination.destination', {


### PR DESCRIPTION
Add default population of image, gallery and programTypes fields in the find method to ensure consistent data retrieval. Uses entityService directly for more control over the query.