### PR TITLE
feat(destination): add menu endpoint to fetch active destinations

### DIFF
--- a/src/api/destination/controllers/destination.js
+++ b/src/api/destination/controllers/destination.js
@@ -143,4 +143,18 @@ module.exports = createCoreController('api::destination.destination', ({ strapi 
     }));
   },
 
+  // Método personalizado para obtener datos del menú (id, name, slug)
+  async findMenu(ctx) {
+    const entities = await strapi.entityService.findMany('api::destination.destination', {
+      filters: { active: true },
+      fields: ['id', 'name', 'slug']
+    });
+
+    return entities.map(entity => ({
+      id: entity.id,
+      name: entity.name,
+      slug: entity.slug
+    }));
+  },
+
 }));

--- a/src/api/destination/routes/custom-routes.js
+++ b/src/api/destination/routes/custom-routes.js
@@ -62,5 +62,13 @@ module.exports = {
         auth: false,
       },
     },
+    {
+      method: 'GET',
+      path: '/destinations/menu',
+      handler: 'destination.findMenu',
+      config: {
+        auth: false,
+      },
+    },
   ],
 };


### PR DESCRIPTION
Add new GET /destinations/menu endpoint that returns id, name and slug of active destinations. This provides a lightweight way to fetch menu data without unnecessary fields.